### PR TITLE
Csi 829 Migrate db to main process

### DIFF
--- a/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
+++ b/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
@@ -15,7 +15,6 @@ import Routes from '../../../constants/routes';
 import {
   Databases,
   dbUtil,
-  transactionDb,
   xpubDb
 } from '../../../store/database';
 import logger from '../../../utils/logger';
@@ -142,7 +141,7 @@ const WalletItem = (props: WalletItemProps) => {
         walletId
       });
       await xpubDb.deleteWallet(walletId);
-      await transactionDb.deleteWallet(walletId);
+      await dbUtil(Databases.TRANSACTION, 'deleteWallet', walletId);
       navigate(Routes.wallet.index);
       setDeleteOpen(false);
       handleClose();

--- a/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
+++ b/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
@@ -12,11 +12,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Routes from '../../../constants/routes';
-import {
-  Databases,
-  dbUtil,
-  xpubDb
-} from '../../../store/database';
+import { Databases, dbUtil } from '../../../store/database';
 import logger from '../../../utils/logger';
 import DeleteWalletIcon from '../../iconGroups/deleteWallet';
 import CustomIconButton from '../buttons/customIconButton';
@@ -133,14 +129,14 @@ const WalletItem = (props: WalletItemProps) => {
         walletDetails: { walletId }
       } = props;
       await dbUtil(Databases.WALLET, 'delete', walletId);
-      const allXpubs = await xpubDb.getByWalletId(walletId);
-      allXpubs.map(async xpub => {
+      const allXpubs = await dbUtil(Databases.XPUB, 'getByWalletId', walletId);
+      allXpubs.map(async (xpub: { xpub: any }) => {
         await dbUtil(Databases.ADDRESS, 'deleteAll', { xpub: xpub.xpub });
       });
       await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
         walletId
       });
-      await xpubDb.deleteWallet(walletId);
+      await dbUtil(Databases.XPUB, 'deleteWallet', walletId);
       await dbUtil(Databases.TRANSACTION, 'deleteWallet', walletId);
       navigate(Routes.wallet.index);
       setDeleteOpen(false);

--- a/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
+++ b/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
@@ -13,7 +13,6 @@ import { useNavigate } from 'react-router-dom';
 
 import Routes from '../../../constants/routes';
 import {
-  addressDb,
   Databases,
   dbUtil,
   transactionDb,
@@ -138,7 +137,7 @@ const WalletItem = (props: WalletItemProps) => {
       await walletDb.delete(walletId);
       const allXpubs = await xpubDb.getByWalletId(walletId);
       allXpubs.map(async xpub => {
-        await addressDb.deleteAll({ xpub: xpub.xpub });
+        await dbUtil(Databases.ADDRESS, 'deleteAll', { xpub: xpub.xpub });
       });
       await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
         walletId

--- a/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
+++ b/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
@@ -16,7 +16,6 @@ import {
   Databases,
   dbUtil,
   transactionDb,
-  walletDb,
   xpubDb
 } from '../../../store/database';
 import logger from '../../../utils/logger';
@@ -134,7 +133,7 @@ const WalletItem = (props: WalletItemProps) => {
       const {
         walletDetails: { walletId }
       } = props;
-      await walletDb.delete(walletId);
+      await dbUtil(Databases.WALLET, 'delete', walletId);
       const allXpubs = await xpubDb.getByWalletId(walletId);
       allXpubs.map(async xpub => {
         await dbUtil(Databases.ADDRESS, 'deleteAll', { xpub: xpub.xpub });

--- a/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
+++ b/cysync/src/designSystem/designComponents/customComponents/walletItem.tsx
@@ -14,7 +14,8 @@ import { useNavigate } from 'react-router-dom';
 import Routes from '../../../constants/routes';
 import {
   addressDb,
-  receiveAddressDb,
+  Databases,
+  dbUtil,
   transactionDb,
   walletDb,
   xpubDb
@@ -139,7 +140,7 @@ const WalletItem = (props: WalletItemProps) => {
       allXpubs.map(async xpub => {
         await addressDb.deleteAll({ xpub: xpub.xpub });
       });
-      await receiveAddressDb.deleteAll({
+      await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
         walletId
       });
       await xpubDb.deleteWallet(walletId);

--- a/cysync/src/index.ts
+++ b/cysync/src/index.ts
@@ -29,6 +29,8 @@ import {
   rimrafPromise
 } from './mainProcess/utils';
 
+import { dbs } from './store/database';
+
 const handleMainProcessError = async (error: any) => {
   logger.error('Unhandled error on main process');
   logger.error(error);
@@ -369,6 +371,14 @@ const createWindow = async () => {
       app.exit(0);
     }
   });
+
+  ipcMain.handle(
+    'database',
+    async (_, dbName: any, fnName: string, arg: any) => {
+      const results = await (dbs as any)[dbName][fnName](arg);
+      return results;
+    }
+  );
 };
 
 app.on('ready', async () => {

--- a/cysync/src/index.ts
+++ b/cysync/src/index.ts
@@ -375,9 +375,14 @@ const createWindow = async () => {
   ipcMain.handle(
     'database',
     async (_, dbName: Databases, fnName: string, ...args: any) => {
-      const results = await (dbs as any)[dbName][fnName].bind(dbs[dbName])(
-        ...args
-      );
+      let results;
+      if (fnName === 'emitter') {
+        results = await (dbs as any)[dbName].emitter[args[0]].bind(dbs[dbName])(
+          ...args.slice(1)
+        );
+      } else {
+        results = await (dbs as any)[dbName][fnName].bind(dbs[dbName])(...args);
+      }
       return results;
     }
   );

--- a/cysync/src/index.ts
+++ b/cysync/src/index.ts
@@ -27,7 +27,8 @@ import {
   installExtensions,
   rimrafPromise
 } from './mainProcess/utils';
-import { Databases, dbs } from './store/database';
+import { Databases } from './store/database';
+import { dbs } from './store/database/databases';
 
 // Sets config variable on envirnment, must be set before any other import
 

--- a/cysync/src/index.ts
+++ b/cysync/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from './mainProcess/utils';
 import { Databases } from './store/database';
 import { dbs } from './store/database/databases';
+import { getAnalyticsId } from './utils/analytics';
 
 // Sets config variable on envirnment, must be set before any other import
 
@@ -401,6 +402,9 @@ const createWindow = async () => {
       });
     });
   }
+  ipcMain.handle('get-analytics-id', async _ => {
+    return getAnalyticsId();
+  });
 };
 
 app.on('ready', async () => {

--- a/cysync/src/index.ts
+++ b/cysync/src/index.ts
@@ -15,7 +15,6 @@ import path from 'path';
 
 import packageJson from '../package.json';
 
-// Sets config variable on envirnment, must be set before any other import
 import './mainProcess';
 import { handleError, reportCrash } from './mainProcess/crashReporter';
 import logger from './mainProcess/logger';
@@ -28,8 +27,9 @@ import {
   installExtensions,
   rimrafPromise
 } from './mainProcess/utils';
+import { Databases, dbs } from './store/database';
 
-import { dbs } from './store/database';
+// Sets config variable on envirnment, must be set before any other import
 
 const handleMainProcessError = async (error: any) => {
   logger.error('Unhandled error on main process');
@@ -374,8 +374,10 @@ const createWindow = async () => {
 
   ipcMain.handle(
     'database',
-    async (_, dbName: any, fnName: string, arg: any) => {
-      const results = await (dbs as any)[dbName][fnName](arg);
+    async (_, dbName: Databases, fnName: string, ...args: any) => {
+      const results = await (dbs as any)[dbName][fnName].bind(dbs[dbName])(
+        ...args
+      );
       return results;
     }
   );

--- a/cysync/src/pages/ExitCleanup.tsx
+++ b/cysync/src/pages/ExitCleanup.tsx
@@ -4,7 +4,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { ipcRenderer } from 'electron';
 import React, { useEffect, useState } from 'react';
 
-import { passEnDb } from '../store/database';
+import { Databases, dbUtil } from '../store/database';
 import { useConnection } from '../store/provider';
 import logger from '../utils/logger';
 
@@ -31,7 +31,7 @@ const ExitCleanup = () => {
           packetVersion: devicePacketVersion,
           sdkVersion: deviceSdkVersion
         });
-        passEnDb.destroyHash();
+        dbUtil(Databases.PASSEN, 'destroyHash');
       } catch (error) {
         logger.error('Error in exit cleanup');
         logger.error(error);

--- a/cysync/src/pages/lockscreen/LockScreen.tsx
+++ b/cysync/src/pages/lockscreen/LockScreen.tsx
@@ -23,7 +23,7 @@ import CySync from '../../designSystem/iconGroups/cySync';
 import CySyncRound from '../../designSystem/iconGroups/cySyncRound';
 import ErrorExclamation from '../../designSystem/iconGroups/errorExclamation';
 import ICONS from '../../designSystem/iconGroups/iconConstants';
-import { loadDatabases, passEnDb } from '../../store/database';
+import { Databases, dbUtil, loadDatabases } from '../../store/database';
 import { FeedbackState, useFeedback } from '../../store/provider';
 import { generateSinglePasswordHash, verifyPassword } from '../../utils/auth';
 import { triggerClearData } from '../../utils/clearData';
@@ -120,7 +120,11 @@ const LockScreen = (props: any) => {
         ...values,
         error: ''
       });
-      passEnDb.setPassHash(generateSinglePasswordHash(values.password.trim()));
+      dbUtil(
+        Databases.PASSEN,
+        'setPassHash',
+        generateSinglePasswordHash(values.password.trim())
+      );
       await loadDatabases();
       props.handleClose();
     } else {

--- a/cysync/src/pages/mainApp/Navbar.tsx
+++ b/cysync/src/pages/mainApp/Navbar.tsx
@@ -8,7 +8,6 @@ import SettingsEthernetIcon from '@material-ui/icons/SettingsEthernet';
 import WarningIcon from '@material-ui/icons/Warning';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { ipcRenderer} from 'electron';
 
 import CustomIconButton from '../../designSystem/designComponents/buttons/customIconButton';
 import Icon from '../../designSystem/designComponents/icons/Icon';
@@ -18,6 +17,7 @@ import Analytics from '../../utils/analytics';
 import logger from '../../utils/logger';
 
 import NotificationComponent from './notification';
+import { dbUtil, Databases } from '../../store/database';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -479,8 +479,8 @@ const Navbar: React.FC<NavbarProps> = ({ handleLock }) => {
         )}
         <button onClick={
           async () => {
-            const result = await ipcRenderer.invoke('database', 'notificationDb', 'getLatest',3);
-            console.log("ipcrendere", result);
+            const result = await dbUtil(Databases.NOTIFICATION, 'getLatest',3);
+            console.log("ipcrenderer", result);
           }
         }>
           <Typography

--- a/cysync/src/pages/mainApp/Navbar.tsx
+++ b/cysync/src/pages/mainApp/Navbar.tsx
@@ -17,7 +17,6 @@ import Analytics from '../../utils/analytics';
 import logger from '../../utils/logger';
 
 import NotificationComponent from './notification';
-import { dbUtil, Databases } from '../../store/database';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -477,19 +476,6 @@ const Navbar: React.FC<NavbarProps> = ({ handleLock }) => {
             }}
           />
         )}
-        <button onClick={
-          async () => {
-            const result = await dbUtil(Databases.NOTIFICATION, 'getLatest',3);
-            console.log("ipcrenderer", result);
-          }
-        }>
-          <Typography
-            variant="body2"
-            className={classes.text}
-            color="secondary">
-            click
-          </Typography>
-        </button>
       </div>
       <div className={classes.rightContent}>
         <Tooltip title={getSyncToolTip()}>

--- a/cysync/src/pages/mainApp/Navbar.tsx
+++ b/cysync/src/pages/mainApp/Navbar.tsx
@@ -8,6 +8,7 @@ import SettingsEthernetIcon from '@material-ui/icons/SettingsEthernet';
 import WarningIcon from '@material-ui/icons/Warning';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import { ipcRenderer} from 'electron';
 
 import CustomIconButton from '../../designSystem/designComponents/buttons/customIconButton';
 import Icon from '../../designSystem/designComponents/icons/Icon';
@@ -476,6 +477,19 @@ const Navbar: React.FC<NavbarProps> = ({ handleLock }) => {
             }}
           />
         )}
+        <button onClick={
+          async () => {
+            const result = await ipcRenderer.invoke('database', 'notificationDb', 'getLatest',3);
+            console.log("ipcrendere", result);
+          }
+        }>
+          <Typography
+            variant="body2"
+            className={classes.text}
+            color="secondary">
+            click
+          </Typography>
+        </button>
       </div>
       <div className={classes.rightContent}>
         <Tooltip title={getSyncToolTip()}>

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -4,7 +4,6 @@ import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
 import {
   Databases,
   dbUtil,
-  priceDb,
   transactionDb,
   walletDb,
   xpubDb
@@ -37,7 +36,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Prices',
-          promise: priceDb.hasIncompatableData.bind(priceDb)
+          promise: dbUtil(Databases.PRICE, 'hasIncompatableData')
         },
         {
           name: 'ERC20 Tokens',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -5,7 +5,6 @@ import {
   addressDb,
   Databases,
   dbUtil,
-  deviceDb,
   erc20tokenDb,
   priceDb,
   receiveAddressDb,
@@ -61,7 +60,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Device',
-          promise: deviceDb.hasIncompatableData.bind(deviceDb)
+          promise: dbUtil(Databases.DEVICE, 'hasIncompatableData')
         }
       ];
 

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
-import {
-  Databases,
-  dbUtil,
-  xpubDb
-} from '../../../store/database';
+import { Databases, dbUtil } from '../../../store/database';
 import Analytics from '../../../utils/analytics';
 import logger from '../../../utils/logger';
 
@@ -22,39 +18,43 @@ const DBCleaupPopup = () => {
       const promiseList = [
         {
           name: 'History',
-          promise: dbUtil(Databases.TRANSACTION, 'hasIncompatableData')
+          promise: async () =>
+            dbUtil(Databases.TRANSACTION, 'hasIncompatableData')
         },
         {
           name: 'Xpub',
-          promise: xpubDb.hasIncompatableData.bind(xpubDb)
+          promise: async () => dbUtil(Databases.XPUB, 'hasIncompatableData')
         },
         {
           name: 'Wallet',
-          promise: dbUtil(Databases.WALLET, 'hasIncompatableData')
+          promise: async () => dbUtil(Databases.WALLET, 'hasIncompatableData')
         },
         {
           name: 'Prices',
-          promise: dbUtil(Databases.PRICE, 'hasIncompatableData')
+          promise: async () => dbUtil(Databases.PRICE, 'hasIncompatableData')
         },
         {
           name: 'ERC20 Tokens',
-          promise: dbUtil(Databases.ERC20TOKEN, 'hasIncompatableData')
+          promise: async () =>
+            dbUtil(Databases.ERC20TOKEN, 'hasIncompatableData')
         },
         {
           name: 'Addresses',
-          promise: dbUtil(Databases.ADDRESS, 'hasIncompatableData')
+          promise: async () => dbUtil(Databases.ADDRESS, 'hasIncompatableData')
         },
         {
           name: 'Receive Address',
-          promise: dbUtil(Databases.RECEIVEADDRESS, 'hasIncompatableData')
+          promise: async () =>
+            dbUtil(Databases.RECEIVEADDRESS, 'hasIncompatableData')
         },
         {
           name: 'Notification',
-          promise: dbUtil(Databases.NOTIFICATION, 'hasIncompatableData')
+          promise: async () =>
+            dbUtil(Databases.NOTIFICATION, 'hasIncompatableData')
         },
         {
           name: 'Device',
-          promise: dbUtil(Databases.DEVICE, 'hasIncompatableData')
+          promise: async () => dbUtil(Databases.DEVICE, 'hasIncompatableData')
         }
       ];
 

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
 import {
-  addressDb,
   Databases,
   dbUtil,
   erc20tokenDb,
@@ -47,7 +46,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Addresses',
-          promise: addressDb.hasIncompatableData.bind(addressDb)
+          promise: dbUtil(Databases.ADDRESS, 'hasIncompatableData')
         },
         {
           name: 'Receive Address',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -4,7 +4,6 @@ import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
 import {
   Databases,
   dbUtil,
-  erc20tokenDb,
   priceDb,
   transactionDb,
   walletDb,
@@ -42,7 +41,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'ERC20 Tokens',
-          promise: erc20tokenDb.hasIncompatableData.bind(erc20tokenDb)
+          promise: dbUtil(Databases.ERC20TOKEN, 'hasIncompatableData')
         },
         {
           name: 'Addresses',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -5,7 +5,6 @@ import {
   Databases,
   dbUtil,
   transactionDb,
-  walletDb,
   xpubDb
 } from '../../../store/database';
 import Analytics from '../../../utils/analytics';
@@ -32,7 +31,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Wallet',
-          promise: walletDb.hasIncompatableData.bind(walletDb)
+          promise: dbUtil(Databases.WALLET, 'hasIncompatableData')
         },
         {
           name: 'Prices',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -3,9 +3,10 @@ import React, { useEffect, useState } from 'react';
 import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
 import {
   addressDb,
+  Databases,
+  dbUtil,
   deviceDb,
   erc20tokenDb,
-  notificationDb,
   priceDb,
   receiveAddressDb,
   transactionDb,
@@ -56,7 +57,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Notification',
-          promise: notificationDb.hasIncompatableData.bind(notificationDb)
+          promise: dbUtil(Databases.NOTIFICATION, 'hasIncompatableData')
         },
         {
           name: 'Device',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -4,7 +4,6 @@ import DialogBox from '../../../designSystem/designComponents/dialog/dialogBox';
 import {
   Databases,
   dbUtil,
-  transactionDb,
   xpubDb
 } from '../../../store/database';
 import Analytics from '../../../utils/analytics';
@@ -23,7 +22,7 @@ const DBCleaupPopup = () => {
       const promiseList = [
         {
           name: 'History',
-          promise: transactionDb.hasIncompatableData.bind(transactionDb)
+          promise: dbUtil(Databases.TRANSACTION, 'hasIncompatableData')
         },
         {
           name: 'Xpub',

--- a/cysync/src/pages/mainApp/dbCleanup/index.tsx
+++ b/cysync/src/pages/mainApp/dbCleanup/index.tsx
@@ -7,7 +7,6 @@ import {
   dbUtil,
   erc20tokenDb,
   priceDb,
-  receiveAddressDb,
   transactionDb,
   walletDb,
   xpubDb
@@ -52,7 +51,7 @@ const DBCleaupPopup = () => {
         },
         {
           name: 'Receive Address',
-          promise: receiveAddressDb.hasIncompatableData.bind(receiveAddressDb)
+          promise: dbUtil(Databases.RECEIVEADDRESS, 'hasIncompatableData')
         },
         {
           name: 'Notification',

--- a/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
@@ -27,7 +27,7 @@ import CoinIcons from '../../../../designSystem/genericComponents/coinIcons';
 import DeleteCoinIcon from '../../../../designSystem/iconGroups/deleteCoin';
 import Dustbin from '../../../../designSystem/iconGroups/dustbin';
 import ICONS from '../../../../designSystem/iconGroups/iconConstants';
-import { Databases, dbUtil, transactionDb } from '../../../../store/database';
+import { Databases, dbUtil } from '../../../../store/database';
 import { useToken } from '../../../../store/hooks';
 import {
   useReceiveTransaction,
@@ -215,7 +215,7 @@ const EthereumOneCoin: React.FC<OneCoinProps> = ({
         walletId,
         coinType: token
       });
-      await transactionDb.deleteByCoin(walletId, token);
+      await dbUtil(Databases.TRANSACTION, 'deleteByCoin', walletId, token);
     });
     await dbUtil(Databases.ERC20TOKEN, 'deleteAll', {
       walletId: selectedWallet.walletId,

--- a/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
@@ -28,7 +28,6 @@ import DeleteCoinIcon from '../../../../designSystem/iconGroups/deleteCoin';
 import Dustbin from '../../../../designSystem/iconGroups/dustbin';
 import ICONS from '../../../../designSystem/iconGroups/iconConstants';
 import {
-  addressDb,
   Databases,
   dbUtil,
   erc20tokenDb,
@@ -213,7 +212,10 @@ const EthereumOneCoin: React.FC<OneCoinProps> = ({
     await deleteHistory(coinDetails);
     await deleteCoin(coinDetails.xpub, coinDetails.coin, walletId);
     tokenList.map(async token => {
-      await addressDb.deleteAll({ xpub: coinDetails.xpub, coinType: token });
+      await dbUtil(Databases.ADDRESS, 'deleteAll', {
+        xpub: coinDetails.xpub,
+        coinType: token
+      });
       await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
         walletId,
         coinType: token

--- a/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
@@ -27,12 +27,7 @@ import CoinIcons from '../../../../designSystem/genericComponents/coinIcons';
 import DeleteCoinIcon from '../../../../designSystem/iconGroups/deleteCoin';
 import Dustbin from '../../../../designSystem/iconGroups/dustbin';
 import ICONS from '../../../../designSystem/iconGroups/iconConstants';
-import {
-  Databases,
-  dbUtil,
-  erc20tokenDb,
-  transactionDb
-} from '../../../../store/database';
+import { Databases, dbUtil, transactionDb } from '../../../../store/database';
 import { useToken } from '../../../../store/hooks';
 import {
   useReceiveTransaction,
@@ -222,7 +217,7 @@ const EthereumOneCoin: React.FC<OneCoinProps> = ({
       });
       await transactionDb.deleteByCoin(walletId, token);
     });
-    await erc20tokenDb.deleteAll({
+    await dbUtil(Databases.ERC20TOKEN, 'deleteAll', {
       walletId: selectedWallet.walletId,
       ethCoin: coinDetails.coin
     });

--- a/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/EthereumOneCoin.tsx
@@ -29,8 +29,9 @@ import Dustbin from '../../../../designSystem/iconGroups/dustbin';
 import ICONS from '../../../../designSystem/iconGroups/iconConstants';
 import {
   addressDb,
+  Databases,
+  dbUtil,
   erc20tokenDb,
-  receiveAddressDb,
   transactionDb
 } from '../../../../store/database';
 import { useToken } from '../../../../store/hooks';
@@ -213,7 +214,10 @@ const EthereumOneCoin: React.FC<OneCoinProps> = ({
     await deleteCoin(coinDetails.xpub, coinDetails.coin, walletId);
     tokenList.map(async token => {
       await addressDb.deleteAll({ xpub: coinDetails.xpub, coinType: token });
-      await receiveAddressDb.deleteAll({ walletId, coinType: token });
+      await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
+        walletId,
+        coinType: token
+      });
       await transactionDb.deleteByCoin(walletId, token);
     });
     await erc20tokenDb.deleteAll({

--- a/cysync/src/pages/mainApp/sidebar/wallet/OneToken.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/OneToken.tsx
@@ -22,7 +22,7 @@ import CoinIcons from '../../../../designSystem/genericComponents/coinIcons';
 import DeleteCoinIcon from '../../../../designSystem/iconGroups/deleteCoin';
 import Dustbin from '../../../../designSystem/iconGroups/dustbin';
 import ICONS from '../../../../designSystem/iconGroups/iconConstants';
-import { erc20tokenDb } from '../../../../store/database';
+import { Databases, dbUtil } from '../../../../store/database';
 import {
   useReceiveTransaction,
   useSendTransaction
@@ -172,7 +172,7 @@ const OneToken: React.FC<OneTokenProps> = ({
   };
 
   const handleDeleteConfirmation = () => {
-    erc20tokenDb.deleteAll({
+    dbUtil(Databases.ERC20TOKEN, 'deleteAll', {
       walletId,
       coin: initial.toLowerCase(),
       ethCoin: ethCoin.toLowerCase()

--- a/cysync/src/pages/mainApp/sidebar/wallet/addToken/addTokenForm.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/addToken/addTokenForm.tsx
@@ -13,7 +13,7 @@ import CustomButton from '../../../../../designSystem/designComponents/buttons/b
 import CustomCheckBox from '../../../../../designSystem/designComponents/input/checkbox';
 import Input from '../../../../../designSystem/designComponents/input/input';
 import CoinIcons from '../../../../../designSystem/genericComponents/coinIcons';
-import { erc20tokenDb } from '../../../../../store/database';
+import { Databases, dbUtil } from '../../../../../store/database';
 import { useDebouncedFunction } from '../../../../../store/hooks';
 import { useSelectedWallet, useSync } from '../../../../../store/provider';
 
@@ -125,7 +125,7 @@ const AddTokenForm = ({ tokenList, ethCoin, handleClose }: any) => {
   const onContinue = () => {
     const tokensToAdd = tokens.filter(token => token[2]).map(token => token[0]);
     tokensToAdd.forEach(tokenName => {
-      erc20tokenDb.insert({
+      dbUtil(Databases.ERC20TOKEN, 'insert', {
         walletId: selectedWallet.walletId,
         coin: tokenName,
         ethCoin: ethCoin.toLowerCase(),

--- a/cysync/src/pages/mainApp/sidebar/wallet/recieve/formStepComponents/Recieve.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/recieve/formStepComponents/Recieve.tsx
@@ -114,7 +114,7 @@ const getReceiveAddress = async (
       xpub,
       zpub,
       addressDbUtil: (...args: any) => {
-        return dbUtil(Databases.ADDRESS, args);
+        return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
       }
     });
     receiveAddress = (await w.newReceiveAddress()).toUpperCase();
@@ -126,7 +126,7 @@ const getReceiveAddress = async (
       xpub,
       zpub,
       addressDbUtil: (...args: any) => {
-        return dbUtil(Databases.ADDRESS, args);
+        return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
       }
     });
     receiveAddress = await w.newReceiveAddress();

--- a/cysync/src/pages/mainApp/sidebar/wallet/recieve/formStepComponents/Recieve.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/recieve/formStepComponents/Recieve.tsx
@@ -16,7 +16,7 @@ import QRCode from 'qrcode';
 import React, { useState } from 'react';
 
 import ErrorDialog from '../../../../../../designSystem/designComponents/dialog/errorDialog';
-import { addressDb } from '../../../../../../store/database';
+import { Databases, dbUtil } from '../../../../../../store/database';
 import {
   useCurrentCoin,
   useReceiveTransactionContext,
@@ -109,12 +109,26 @@ const getReceiveAddress = async (
   }
 
   if (coin.isEth) {
-    w = wallet({ coinType, xpub, zpub, addressDB: addressDb });
+    w = wallet({
+      coinType,
+      xpub,
+      zpub,
+      addressDbUtil: (...args: any) => {
+        return dbUtil(Databases.ADDRESS, args);
+      }
+    });
     receiveAddress = (await w.newReceiveAddress()).toUpperCase();
     // To make the first x in lowercase
     receiveAddress = `0x${receiveAddress.slice(2)}`;
   } else {
-    w = wallet({ coinType, xpub, zpub, addressDB: addressDb });
+    w = wallet({
+      coinType,
+      xpub,
+      zpub,
+      addressDbUtil: (...args: any) => {
+        return dbUtil(Databases.ADDRESS, args);
+      }
+    });
     receiveAddress = await w.newReceiveAddress();
   }
   return receiveAddress;

--- a/cysync/src/pages/mainApp/updater/device/index.tsx
+++ b/cysync/src/pages/mainApp/updater/device/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import Routes from '../../../../constants/routes';
 import DialogBox from '../../../../designSystem/designComponents/dialog/dialogBox';
-import { deviceDb } from '../../../../store/database';
+import { Databases, dbUtil } from '../../../../store/database';
 import { useConnection, useUpdater } from '../../../../store/provider';
 import { compareVersion } from '../../../../utils/compareVersion';
 import logger from '../../../../utils/logger';
@@ -23,8 +23,7 @@ const Updater = () => {
     if (isDeviceUpdateAvailable && verifyState === 0) {
       const lastVersion = localStorage.getItem('last-device-version');
       if (deviceSerial !== null) {
-        deviceDb
-          .getBySerial(deviceSerial)
+        dbUtil(Databases.DEVICE, 'getBySerial', deviceSerial)
           .then(device => {
             if (!device) {
               return;

--- a/cysync/src/store/database/databaseInit.ts
+++ b/cysync/src/store/database/databaseInit.ts
@@ -39,7 +39,8 @@ export const dbs = {
   addressDb,
   receiveAddressDb,
   notificationDb,
-  deviceDb
+  deviceDb,
+  passEnDb
 };
 
 export enum Databases {
@@ -51,7 +52,8 @@ export enum Databases {
   ADDRESS = 'addressDb',
   RECEIVEADDRESS = 'receiveAddressDb',
   NOTIFICATION = 'notificationDb',
-  DEVICE = 'deviceDb'
+  DEVICE = 'deviceDb',
+  PASSEN = 'passEnDb'
 }
 
 export const dbUtil = async (
@@ -66,7 +68,7 @@ export const dbUtil = async (
  * Loads the data from disk. To be used only for encrypted databases.
  */
 export const loadDatabases = async () => {
-  await xpubDb.loadData();
+  await dbUtil(Databases.XPUB, 'loadData');
 };
 
 export * from '@cypherock/database';

--- a/cysync/src/store/database/databaseInit.ts
+++ b/cysync/src/store/database/databaseInit.ts
@@ -11,8 +11,9 @@ import {
   WalletDB,
   XpubDB
 } from '@cypherock/database';
+import { ipcRenderer } from 'electron';
 
-import { getAnalyticsId } from '../../utils/analytics';
+// import { getAnalyticsId } from '../../utils/analytics';
 
 const dbPath = process.env.userDataPath;
 
@@ -39,7 +40,27 @@ export const dbs = {
   receiveAddressDb,
   notificationDb,
   deviceDb
+};
+
+export enum Databases {
+  PRICE = 'priceDb',
+  XPUB = 'xpubDb',
+  TRANSACTION = 'transactionDb',
+  WALLET = 'walletDb',
+  ERC20TOKEN = 'erc20tokenDb',
+  ADDRESS = 'addressDb',
+  RECEIVEADDRESS = 'receiveAddressDb',
+  NOTIFICATION = 'notificationDb',
+  DEVICE = 'deviceDb'
 }
+
+export const dbUtil = async (
+  dbName: Databases,
+  fnName: string,
+  ...args: any
+) => {
+  return await ipcRenderer.invoke('database', dbName, fnName, ...args);
+};
 
 /**
  * Loads the data from disk. To be used only for encrypted databases.

--- a/cysync/src/store/database/databaseInit.ts
+++ b/cysync/src/store/database/databaseInit.ts
@@ -1,47 +1,4 @@
-import {
-  AddressDB,
-  DeviceDB,
-  Erc20DB,
-  LatestPriceDB,
-  NotificationDB,
-  PassEncrypt,
-  PriceDB,
-  ReceiveAddressDB,
-  TransactionDB,
-  WalletDB,
-  XpubDB
-} from '@cypherock/database';
 import { ipcRenderer } from 'electron';
-
-// import { getAnalyticsId } from '../../utils/analytics';
-
-const dbPath = process.env.userDataPath;
-
-export const passEnDb = new PassEncrypt('adfds-dsfaf');
-
-export const priceDb = new PriceDB(dbPath);
-export const latestPriceDb = new LatestPriceDB(dbPath);
-export const xpubDb = new XpubDB(dbPath, passEnDb);
-export const transactionDb = new TransactionDB(dbPath);
-export const walletDb = new WalletDB(dbPath);
-export const erc20tokenDb = new Erc20DB(dbPath);
-export const addressDb = new AddressDB(dbPath);
-export const receiveAddressDb = new ReceiveAddressDB(dbPath);
-export const notificationDb = new NotificationDB(dbPath);
-export const deviceDb = new DeviceDB(dbPath);
-
-export const dbs = {
-  priceDb,
-  xpubDb,
-  transactionDb,
-  walletDb,
-  erc20tokenDb,
-  addressDb,
-  receiveAddressDb,
-  notificationDb,
-  deviceDb,
-  passEnDb
-};
 
 export enum Databases {
   PRICE = 'priceDb',

--- a/cysync/src/store/database/databaseInit.ts
+++ b/cysync/src/store/database/databaseInit.ts
@@ -16,7 +16,7 @@ import { getAnalyticsId } from '../../utils/analytics';
 
 const dbPath = process.env.userDataPath;
 
-export const passEnDb = new PassEncrypt(getAnalyticsId());
+export const passEnDb = new PassEncrypt('adfds-dsfaf');
 
 export const priceDb = new PriceDB(dbPath);
 export const latestPriceDb = new LatestPriceDB(dbPath);
@@ -28,6 +28,18 @@ export const addressDb = new AddressDB(dbPath);
 export const receiveAddressDb = new ReceiveAddressDB(dbPath);
 export const notificationDb = new NotificationDB(dbPath);
 export const deviceDb = new DeviceDB(dbPath);
+
+export const dbs = {
+  priceDb,
+  xpubDb,
+  transactionDb,
+  walletDb,
+  erc20tokenDb,
+  addressDb,
+  receiveAddressDb,
+  notificationDb,
+  deviceDb
+}
 
 /**
  * Loads the data from disk. To be used only for encrypted databases.

--- a/cysync/src/store/database/databaseInit.ts
+++ b/cysync/src/store/database/databaseInit.ts
@@ -2,6 +2,7 @@ import { ipcRenderer } from 'electron';
 
 export enum Databases {
   PRICE = 'priceDb',
+  LATESTPRICE = 'latestPriceDb',
   XPUB = 'xpubDb',
   TRANSACTION = 'transactionDb',
   WALLET = 'walletDb',

--- a/cysync/src/store/database/databases.ts
+++ b/cysync/src/store/database/databases.ts
@@ -13,11 +13,11 @@ import {
   } from '@cypherock/database';
   
   
-  // import { getAnalyticsId } from '../../utils/analytics';
+  import { getAnalyticsId } from '../../utils/analytics';
   
   const dbPath = process.env.userDataPath;
   
-  const passEnDb = new PassEncrypt('adfds-dsfaf');
+  const passEnDb = new PassEncrypt(getAnalyticsId());
   
   const priceDb = new PriceDB(dbPath);
   const xpubDb = new XpubDB(dbPath, passEnDb);

--- a/cysync/src/store/database/databases.ts
+++ b/cysync/src/store/database/databases.ts
@@ -1,44 +1,44 @@
 import {
-    AddressDB,
-    DeviceDB,
-    Erc20DB,
-    NotificationDB,
-    PassEncrypt,
-    PriceDB,
-    ReceiveAddressDB,
-    TransactionDB,
-    WalletDB,
-    XpubDB,
-    LatestPriceDB
-  } from '@cypherock/database';
-  
-  
-  import { getAnalyticsId } from '../../utils/analytics';
-  
-  const dbPath = process.env.userDataPath;
-  
-  const passEnDb = new PassEncrypt(getAnalyticsId());
-  
-  const priceDb = new PriceDB(dbPath);
-  const xpubDb = new XpubDB(dbPath, passEnDb);
-  const transactionDb = new TransactionDB(dbPath);
-  const walletDb = new WalletDB(dbPath);
-  const erc20tokenDb = new Erc20DB(dbPath);
-  const addressDb = new AddressDB(dbPath);
-  const receiveAddressDb = new ReceiveAddressDB(dbPath);
-  const notificationDb = new NotificationDB(dbPath);
-  const deviceDb = new DeviceDB(dbPath);
-export const latestPriceDb = new LatestPriceDB(dbPath);
-  
+  AddressDB,
+  DeviceDB,
+  Erc20DB,
+  LatestPriceDB,
+  NotificationDB,
+  PassEncrypt,
+  PriceDB,
+  ReceiveAddressDB,
+  TransactionDB,
+  WalletDB,
+  XpubDB
+} from '@cypherock/database';
+
+import { getAnalyticsId } from '../../utils/analytics';
+
+const dbPath = process.env.userDataPath;
+
+const passEnDb = new PassEncrypt(getAnalyticsId());
+
+const priceDb = new PriceDB(dbPath);
+const xpubDb = new XpubDB(dbPath, passEnDb);
+const transactionDb = new TransactionDB(dbPath);
+const walletDb = new WalletDB(dbPath);
+const erc20tokenDb = new Erc20DB(dbPath);
+const addressDb = new AddressDB(dbPath);
+const receiveAddressDb = new ReceiveAddressDB(dbPath);
+const notificationDb = new NotificationDB(dbPath);
+const deviceDb = new DeviceDB(dbPath);
+const latestPriceDb = new LatestPriceDB(dbPath);
+
 export const dbs = {
-    priceDb,
-    xpubDb,
-    transactionDb,
-    walletDb,
-    erc20tokenDb,
-    addressDb,
-    receiveAddressDb,
-    notificationDb,
-    deviceDb,
-    passEnDb
-  };
+  priceDb,
+  latestPriceDb,
+  xpubDb,
+  transactionDb,
+  walletDb,
+  erc20tokenDb,
+  addressDb,
+  receiveAddressDb,
+  notificationDb,
+  deviceDb,
+  passEnDb
+};

--- a/cysync/src/store/database/databases.ts
+++ b/cysync/src/store/database/databases.ts
@@ -1,0 +1,44 @@
+import {
+    AddressDB,
+    DeviceDB,
+    Erc20DB,
+    NotificationDB,
+    PassEncrypt,
+    PriceDB,
+    ReceiveAddressDB,
+    TransactionDB,
+    WalletDB,
+    XpubDB,
+    LatestPriceDB
+  } from '@cypherock/database';
+  
+  
+  // import { getAnalyticsId } from '../../utils/analytics';
+  
+  const dbPath = process.env.userDataPath;
+  
+  const passEnDb = new PassEncrypt('adfds-dsfaf');
+  
+  const priceDb = new PriceDB(dbPath);
+  const xpubDb = new XpubDB(dbPath, passEnDb);
+  const transactionDb = new TransactionDB(dbPath);
+  const walletDb = new WalletDB(dbPath);
+  const erc20tokenDb = new Erc20DB(dbPath);
+  const addressDb = new AddressDB(dbPath);
+  const receiveAddressDb = new ReceiveAddressDB(dbPath);
+  const notificationDb = new NotificationDB(dbPath);
+  const deviceDb = new DeviceDB(dbPath);
+export const latestPriceDb = new LatestPriceDB(dbPath);
+  
+export const dbs = {
+    priceDb,
+    xpubDb,
+    transactionDb,
+    walletDb,
+    erc20tokenDb,
+    addressDb,
+    receiveAddressDb,
+    notificationDb,
+    deviceDb,
+    passEnDb
+  };

--- a/cysync/src/store/database/helper.ts
+++ b/cysync/src/store/database/helper.ts
@@ -1,5 +1,4 @@
 import { ALLCOINS } from '@cypherock/communication';
-import ILatestPrice from '@cypherock/database/dist/models/latestPrice';
 
 import logger from '../../utils/logger';
 
@@ -8,11 +7,10 @@ import { Databases, dbUtil } from './databaseInit';
 export const getLatestPriceForCoin = async (coin: string) => {
   if (ALLCOINS[coin] && ALLCOINS[coin].isTest) return 0;
 
-  return dbUtil(Databases.PRICE, 'getPrice', coin.toLowerCase(), 7).then(
+  return dbUtil(Databases.LATESTPRICE, 'getPrice', coin.toLowerCase()).then(
     res => {
       if (res) {
-        const { length } = res.data;
-        return res.data[length - 1][1];
+        return res.price;
       }
       logger.warn(`Cannot find price for coin ${coin}`);
       return 0;

--- a/cysync/src/store/database/helper.ts
+++ b/cysync/src/store/database/helper.ts
@@ -3,20 +3,21 @@ import ILatestPrice from '@cypherock/database/dist/models/latestPrice';
 
 import logger from '../../utils/logger';
 
-import { latestPriceDb } from './databaseInit';
+import { Databases, dbUtil } from './databaseInit';
 
 export const getLatestPriceForCoin = async (coin: string) => {
   if (ALLCOINS[coin] && ALLCOINS[coin].isTest) return 0;
 
-  return latestPriceDb
-    .getPrice(coin.toLowerCase())
-    .then((res: ILatestPrice) => {
+  return dbUtil(Databases.PRICE, 'getPrice', coin.toLowerCase(), 7).then(
+    res => {
       if (res) {
-        return res.price;
+        const { length } = res.data;
+        return res.data[length - 1][1];
       }
       logger.warn(`Cannot find price for coin ${coin}`);
       return 0;
-    });
+    }
+  );
 };
 
 export const getLatestPriceForCoins = async (coins: string[]) => {

--- a/cysync/src/store/hooks/flows/useAddCoin.ts
+++ b/cysync/src/store/hooks/flows/useAddCoin.ts
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { addressDb, Xpub, xpubDb } from '../../database';
+import { Databases, dbUtil, Xpub, xpubDb } from '../../database';
 import { useI18n, useSync } from '../../provider';
 
 function sleep(ms: number) {
@@ -166,7 +166,9 @@ export const useAddCoin: UseAddCoin = () => {
           coinType: xpub.coin,
           xpub: xpub.xpub,
           zpub: xpub.zpub,
-          addressDB: addressDb
+          addressDbUtil: (...args: any) => {
+            return dbUtil(Databases.ADDRESS, args);
+          }
         });
         await wallet.setupNewWallet();
         await xpubDb.insert(xpub);

--- a/cysync/src/store/hooks/flows/useAddCoin.ts
+++ b/cysync/src/store/hooks/flows/useAddCoin.ts
@@ -167,7 +167,7 @@ export const useAddCoin: UseAddCoin = () => {
           xpub: xpub.xpub,
           zpub: xpub.zpub,
           addressDbUtil: (...args: any) => {
-            return dbUtil(Databases.ADDRESS, args);
+            return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
           }
         });
         await wallet.setupNewWallet();

--- a/cysync/src/store/hooks/flows/useAddCoin.ts
+++ b/cysync/src/store/hooks/flows/useAddCoin.ts
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { Databases, dbUtil, Xpub, xpubDb } from '../../database';
+import { Databases, dbUtil, Xpub } from '../../database';
 import { useI18n, useSync } from '../../provider';
 
 function sleep(ms: number) {
@@ -171,7 +171,7 @@ export const useAddCoin: UseAddCoin = () => {
           }
         });
         await wallet.setupNewWallet();
-        await xpubDb.insert(xpub);
+        await dbUtil(Databases.XPUB, 'insert', xpub);
         coinStatus[addCoinIndex].status = 2;
       } catch (error) {
         coinStatus[addCoinIndex].status = -1;

--- a/cysync/src/store/hooks/flows/useAddWallet.ts
+++ b/cysync/src/store/hooks/flows/useAddWallet.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { walletDb } from '../../database';
+import { Databases, dbUtil } from '../../database';
 import { useI18n, useWallets } from '../../provider';
 
 export interface HandleAddWalletOptions {
@@ -156,7 +156,7 @@ export const useAddWallet: UseAddWallet = () => {
           return;
         }
 
-        const walletWithSameId = await walletDb.getAll({
+        const walletWithSameId = await dbUtil(Databases.WALLET, 'getAll', {
           walletId: walletDetails.walletId
         });
 
@@ -181,8 +181,7 @@ export const useAddWallet: UseAddWallet = () => {
           return;
         }
 
-        walletDb
-          .insert(walletDetails)
+        dbUtil(Databases.WALLET, 'insert', walletDetails)
           .then(() => {
             setWalletName(walletDetails.name);
             setWalletId(walletDetails.walletId);
@@ -255,7 +254,7 @@ export const useAddWallet: UseAddWallet = () => {
         throw new Error('New Wallet details are missing');
       }
 
-      const walletWithSameId = await walletDb.getAll({
+      const walletWithSameId = await dbUtil(Databases.WALLET, 'getAll', {
         walletId
       });
 
@@ -267,7 +266,7 @@ export const useAddWallet: UseAddWallet = () => {
       duplicateWallet.name = walletName;
       duplicateWallet.passphraseSet = passphraseSet;
       duplicateWallet.passwordSet = passwordSet;
-      await walletDb.update(duplicateWallet);
+      await dbUtil(Databases.WALLET, 'update', duplicateWallet);
       setIsNameDiff(false);
       setErrorMessage('');
       setWalletSuccess(true);

--- a/cysync/src/store/hooks/flows/useDeviceAuth.ts
+++ b/cysync/src/store/hooks/flows/useDeviceAuth.ts
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { deviceDb } from '../../database';
+import { Databases, dbUtil } from '../../database';
 import { useI18n } from '../../provider';
 
 export interface HandleDeviceAuthOptions {
@@ -72,7 +72,7 @@ export const useDeviceAuth: UseDeviceAuth = isInitial => {
         version: firmwareVersion,
         isAuth: auth
       };
-      deviceDb.insert(device);
+      dbUtil(Databases.DEVICE, 'insert', device);
     } catch (error) {
       logger.error('Error while inserting device auth data');
       logger.error(error);

--- a/cysync/src/store/hooks/flows/useGetDeviceInfo.ts
+++ b/cysync/src/store/hooks/flows/useGetDeviceInfo.ts
@@ -12,7 +12,7 @@ import { useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { deviceDb } from '../../database';
+import { Databases, dbUtil } from '../../database';
 import { useI18n } from '../../provider';
 
 export type UpdateRequiredType = 'app' | 'device' | 'all' | undefined;
@@ -190,7 +190,9 @@ export const useGetDeviceInfo: UseGetDeviceInfo = () => {
         connection,
         packetVersion: PacketVersionMap.v1,
         sdkVersion: '',
-        deviceDB: deviceDb
+        deviceDbUtil: (...args: any) => {
+          return dbUtil(Databases.DEVICE, args[0], ...args.splice(1));
+        }
       });
       setIsInFlow(false);
       logger.info('GetDeviceInfo: Completed.');

--- a/cysync/src/store/hooks/flows/useReceiveTransation.ts
+++ b/cysync/src/store/hooks/flows/useReceiveTransation.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { addressDb, Databases, dbUtil } from '../../database';
+import { Databases, dbUtil } from '../../database';
 import { useI18n, useSocket } from '../../provider';
 
 export interface HandleReceiveTransactionOptions {
@@ -307,7 +307,9 @@ export const useReceiveTransaction: UseReceiveTransaction = () => {
           connection,
           packetVersion,
           sdkVersion,
-          addressDB: addressDb,
+          addressDbUtil: (...args: any) => {
+            return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
+          },
           walletId,
           coinType,
           xpub,

--- a/cysync/src/store/hooks/flows/useReceiveTransation.ts
+++ b/cysync/src/store/hooks/flows/useReceiveTransation.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { addressDb, receiveAddressDb } from '../../database';
+import { addressDb, Databases, dbUtil } from '../../database';
 import { useI18n, useSocket } from '../../provider';
 
 export interface HandleReceiveTransactionOptions {
@@ -96,7 +96,11 @@ export const useReceiveTransaction: UseReceiveTransaction = () => {
   ) => {
     logger.info('New receive address', { coinType, walletId, addr });
     addReceiveAddressHook(addr, walletId, coinType);
-    receiveAddressDb.insert({ address: addr, walletId, coinType });
+    dbUtil(Databases.RECEIVEADDRESS, 'insert', {
+      address: addr,
+      walletId,
+      coinType
+    });
   };
 
   const handleReceiveTransaction: UseReceiveTransactionValues['handleReceiveTransaction'] =

--- a/cysync/src/store/hooks/flows/useSendTransaction.ts
+++ b/cysync/src/store/hooks/flows/useSendTransaction.ts
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { Databases, dbUtil, transactionDb } from '../../database';
+import { Databases, dbUtil } from '../../database';
 import { useI18n } from '../../provider';
 
 export const changeFormatOfOutputList = (
@@ -700,7 +700,7 @@ export const useSendTransaction: UseSendTransaction = () => {
           blockHeight: -1,
           ethCoin: coin
         };
-        transactionDb.insert(feeTxn);
+        dbUtil(Databases.TRANSACTION, 'insert', feeTxn);
       } else {
         tx = {
           hash: txHash.toLowerCase(),
@@ -718,7 +718,7 @@ export const useSendTransaction: UseSendTransaction = () => {
           outputs: formattedOutputs
         };
       }
-      transactionDb.insert(tx);
+      dbUtil(Databases.TRANSACTION, 'insert', tx);
     } catch (error) {
       logger.error('Error in onTxnBroadcast');
       logger.error(error);

--- a/cysync/src/store/hooks/flows/useSendTransaction.ts
+++ b/cysync/src/store/hooks/flows/useSendTransaction.ts
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import SerialPort from 'serialport';
 
 import logger from '../../../utils/logger';
-import { addressDb, transactionDb } from '../../database';
+import { Databases, dbUtil, transactionDb } from '../../database';
 import { useI18n } from '../../provider';
 
 export const changeFormatOfOutputList = (
@@ -562,7 +562,9 @@ export const useSendTransaction: UseSendTransaction = () => {
           connection,
           packetVersion,
           sdkVersion,
-          addressDB: addressDb,
+          addressDbUtil: (...args: any) => {
+            return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
+          },
           walletId,
           pinExists,
           passphraseExists,

--- a/cysync/src/store/hooks/useHistory.ts
+++ b/cysync/src/store/hooks/useHistory.ts
@@ -3,7 +3,12 @@ import { Xpub } from '@cypherock/database';
 import BigNumber from 'bignumber.js';
 
 import logger from '../../utils/logger';
-import { getLatestPriceForCoins, transactionDb, walletDb } from '../database';
+import {
+  Databases,
+  dbUtil,
+  getLatestPriceForCoins,
+  transactionDb
+} from '../database';
 
 import { DisplayInputOutput, DisplayTransaction } from './types';
 
@@ -37,7 +42,7 @@ export const useHistory: UseHistory = () => {
       sort: 'confirmed',
       order: 'd'
     });
-    const allWallets = await walletDb.getAll();
+    const allWallets = await dbUtil(Databases.WALLET, 'getAll');
     const latestTransactionsWithPrice: DisplayTransaction[] = [];
 
     const allUniqueCoins = new Set<string>();
@@ -128,7 +133,9 @@ export const useHistory: UseHistory = () => {
 
       newTxn.isErc20 = isErc20;
 
-      const wallet = allWallets.find(ob => ob.walletId === newTxn.walletId);
+      const wallet = allWallets.find(
+        (ob: { walletId: string }) => ob.walletId === newTxn.walletId
+      );
       if (!wallet) {
         logger.warn(`Cannot find wallet with name: ${newTxn.walletId}`);
       } else {

--- a/cysync/src/store/hooks/useHistory.ts
+++ b/cysync/src/store/hooks/useHistory.ts
@@ -3,12 +3,7 @@ import { Xpub } from '@cypherock/database';
 import BigNumber from 'bignumber.js';
 
 import logger from '../../utils/logger';
-import {
-  Databases,
-  dbUtil,
-  getLatestPriceForCoins,
-  transactionDb
-} from '../database';
+import { Databases, dbUtil, getLatestPriceForCoins } from '../database';
 
 import { DisplayInputOutput, DisplayTransaction } from './types';
 
@@ -38,7 +33,7 @@ export const useHistory: UseHistory = () => {
     if (coinType) {
       query.coin = coinType;
     }
-    const res = await transactionDb.getAll(query, {
+    const res = await dbUtil(Databases.TRANSACTION, 'getAll', query, {
       sort: 'confirmed',
       order: 'd'
     });
@@ -76,7 +71,7 @@ export const useHistory: UseHistory = () => {
       }
 
       if (txn.inputs) {
-        inputs = txn.inputs.map(elem => {
+        inputs = txn.inputs.map((elem: { value: any }) => {
           const val = new BigNumber(elem.value || 0)
             .dividedBy(coin.multiplier)
             .toString();
@@ -89,7 +84,7 @@ export const useHistory: UseHistory = () => {
       }
 
       if (txn.outputs) {
-        outputs = txn.outputs.map(elem => {
+        outputs = txn.outputs.map((elem: { value: any }) => {
           const val = new BigNumber(elem.value || 0)
             .dividedBy(coin.multiplier)
             .toString();
@@ -149,7 +144,12 @@ export const useHistory: UseHistory = () => {
   };
 
   const deleteCoinHistory = (xpub: Xpub) => {
-    return transactionDb.deleteByCoin(xpub.walletId, xpub.coin);
+    return dbUtil(
+      Databases.TRANSACTION,
+      'deleteByCoin',
+      xpub.walletId,
+      xpub.coin
+    );
   };
 
   return {

--- a/cysync/src/store/hooks/usePortfolio.ts
+++ b/cysync/src/store/hooks/usePortfolio.ts
@@ -7,7 +7,6 @@ import logger from '../../utils/logger';
 import {
   Databases,
   dbUtil,
-  priceDb,
   Transaction,
   transactionDb,
   xpubDb
@@ -103,9 +102,9 @@ export const usePortfolio: UsePortfolio = () => {
       debouncedRefreshFromDB
     );
 
-    priceDb.emitter.on('insert', debouncedRefreshFromDB);
-    priceDb.emitter.on('insert', debouncedRefreshFromDB);
-    priceDb.emitter.on('update', debouncedRefreshFromDB);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', debouncedRefreshFromDB);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', debouncedRefreshFromDB);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'delete', debouncedRefreshFromDB);
 
     xpubDb.emitter.on('update', debouncedRefreshFromDB);
     xpubDb.emitter.on('delete', debouncedRefreshFromDB);
@@ -138,9 +137,27 @@ export const usePortfolio: UsePortfolio = () => {
         debouncedRefreshFromDB
       );
 
-      priceDb.emitter.removeListener('insert', debouncedRefreshFromDB);
-      priceDb.emitter.removeListener('insert', debouncedRefreshFromDB);
-      priceDb.emitter.removeListener('update', debouncedRefreshFromDB);
+      dbUtil(
+        Databases.PRICE,
+        'emitter',
+        'removeListener',
+        'insert',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.PRICE,
+        'emitter',
+        'removeListener',
+        'update',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.PRICE,
+        'emitter',
+        'oremoveListenern',
+        'delete',
+        debouncedRefreshFromDB
+      );
 
       xpubDb.emitter.removeListener('update', debouncedRefreshFromDB);
       xpubDb.emitter.removeListener('delete', debouncedRefreshFromDB);
@@ -163,7 +180,7 @@ export const usePortfolio: UsePortfolio = () => {
     }
 
     let totalBalance = new BigNumber(0);
-    const allPrices = await priceDb.getPrice(coinType, days);
+    const allPrices = await dbUtil(Databases.PRICE, 'getPrice', coinType, days);
     if (!allPrices) {
       return null;
     }
@@ -431,7 +448,7 @@ export const usePortfolio: UsePortfolio = () => {
           setHasCoins(true);
         }
 
-        const res = await priceDb.getPrice(coinType, 7);
+        const res = await dbUtil(Databases.PRICE, 'getPrice', coinType, 7);
 
         let latestPrice = 0;
         if (res && res.data) {

--- a/cysync/src/store/hooks/usePortfolio.ts
+++ b/cysync/src/store/hooks/usePortfolio.ts
@@ -4,13 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { getPortfolioCache } from '../../utils/cache';
 import logger from '../../utils/logger';
-import {
-  Databases,
-  dbUtil,
-  Transaction,
-  transactionDb,
-  xpubDb
-} from '../database';
+import { Databases, dbUtil, Transaction, xpubDb } from '../database';
 
 import { CoinDetails, CoinHistory, CoinPriceHistory } from './types';
 import { useDebouncedFunction } from './useDebounce';
@@ -110,9 +104,27 @@ export const usePortfolio: UsePortfolio = () => {
     xpubDb.emitter.on('delete', debouncedRefreshFromDB);
     xpubDb.emitter.on('delete', debouncedRefreshFromDB);
 
-    transactionDb.emitter.on('insert', debouncedRefreshFromDB);
-    transactionDb.emitter.on('update', debouncedRefreshFromDB);
-    transactionDb.emitter.on('delete', debouncedRefreshFromDB);
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'insert',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'update',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'delete',
+      debouncedRefreshFromDB
+    );
 
     return () => {
       dbUtil(
@@ -163,9 +175,27 @@ export const usePortfolio: UsePortfolio = () => {
       xpubDb.emitter.removeListener('delete', debouncedRefreshFromDB);
       xpubDb.emitter.removeListener('delete', debouncedRefreshFromDB);
 
-      transactionDb.emitter.removeListener('insert', debouncedRefreshFromDB);
-      transactionDb.emitter.removeListener('update', debouncedRefreshFromDB);
-      transactionDb.emitter.removeListener('delete', debouncedRefreshFromDB);
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'insert',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'update',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'delete',
+        debouncedRefreshFromDB
+      );
     };
   }, []);
 
@@ -210,7 +240,9 @@ export const usePortfolio: UsePortfolio = () => {
         else return null;
       }
 
-      transactionHistory = await transactionDb.getAll(
+      transactionHistory = await dbUtil(
+        Databases.TRANSACTION,
+        'getAll',
         {
           walletId: wallet,
           coin: coinType,
@@ -240,7 +272,9 @@ export const usePortfolio: UsePortfolio = () => {
         }
       }
 
-      transactionHistory = await transactionDb.getAll(
+      transactionHistory = await dbUtil(
+        Databases.TRANSACTION,
+        'getAll',
         { coin: coinType, excludeFailed: true, excludePending: true },
         { sort: 'confirmed', order: 'd' }
       );

--- a/cysync/src/store/hooks/usePortfolio.ts
+++ b/cysync/src/store/hooks/usePortfolio.ts
@@ -5,7 +5,8 @@ import { useEffect, useState } from 'react';
 import { getPortfolioCache } from '../../utils/cache';
 import logger from '../../utils/logger';
 import {
-  erc20tokenDb,
+  Databases,
+  dbUtil,
   priceDb,
   Transaction,
   transactionDb,
@@ -80,9 +81,27 @@ export const usePortfolio: UsePortfolio = () => {
   const debouncedRefreshFromDB = useDebouncedFunction(refreshFromDB, 2000);
 
   useEffect(() => {
-    erc20tokenDb.emitter.on('insert', debouncedRefreshFromDB);
-    erc20tokenDb.emitter.on('update', debouncedRefreshFromDB);
-    erc20tokenDb.emitter.on('delete', debouncedRefreshFromDB);
+    dbUtil(
+      Databases.ERC20TOKEN,
+      'emitter',
+      'on',
+      'insert',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.ERC20TOKEN,
+      'emitter',
+      'on',
+      'update',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.ERC20TOKEN,
+      'emitter',
+      'on',
+      'delete',
+      debouncedRefreshFromDB
+    );
 
     priceDb.emitter.on('insert', debouncedRefreshFromDB);
     priceDb.emitter.on('insert', debouncedRefreshFromDB);
@@ -97,9 +116,27 @@ export const usePortfolio: UsePortfolio = () => {
     transactionDb.emitter.on('delete', debouncedRefreshFromDB);
 
     return () => {
-      erc20tokenDb.emitter.removeListener('insert', debouncedRefreshFromDB);
-      erc20tokenDb.emitter.removeListener('update', debouncedRefreshFromDB);
-      erc20tokenDb.emitter.removeListener('delete', debouncedRefreshFromDB);
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'insert',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'update',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'delete',
+        debouncedRefreshFromDB
+      );
 
       priceDb.emitter.removeListener('insert', debouncedRefreshFromDB);
       priceDb.emitter.removeListener('insert', debouncedRefreshFromDB);
@@ -139,7 +176,9 @@ export const usePortfolio: UsePortfolio = () => {
 
     if (wallet && wallet !== 'null') {
       if (coin.isErc20Token) {
-        const token = await erc20tokenDb.getByWalletIdandToken(
+        const token = await dbUtil(
+          Databases.ERC20TOKEN,
+          'getByWalletIdandToken',
           wallet,
           coinType
         );
@@ -165,7 +204,11 @@ export const usePortfolio: UsePortfolio = () => {
       );
     } else {
       if (coin.isErc20Token) {
-        const tokens = await erc20tokenDb.getByToken(coinType);
+        const tokens = await dbUtil(
+          Databases.ERC20TOKEN,
+          'getByToken',
+          coinType
+        );
         if (tokens.length === 0) return null;
         for (const token of tokens) {
           totalBalance = totalBalance.plus(token.balance);
@@ -348,7 +391,9 @@ export const usePortfolio: UsePortfolio = () => {
 
         if (walletId && walletId !== 'null') {
           if (coin.isErc20Token) {
-            const token = await erc20tokenDb.getByWalletIdandToken(
+            const token = await dbUtil(
+              Databases.ERC20TOKEN,
+              'getByWalletIdandToken',
               walletId,
               coinType
             );
@@ -363,7 +408,11 @@ export const usePortfolio: UsePortfolio = () => {
             else continue;
           }
         } else if (coin.isErc20Token) {
-          const tokens = await erc20tokenDb.getByToken(coinType);
+          const tokens = await dbUtil(
+            Databases.ERC20TOKEN,
+            'getByToken',
+            coinType
+          );
           if (tokens.length === 0) continue;
           for (const token of tokens) {
             totalBalance = totalBalance.plus(token.balance);

--- a/cysync/src/store/hooks/usePortfolio.ts
+++ b/cysync/src/store/hooks/usePortfolio.ts
@@ -1,5 +1,6 @@
 import { ALLCOINS as COINS } from '@cypherock/communication';
 import BigNumber from 'bignumber.js';
+import { ipcRenderer } from 'electron';
 import { useEffect, useState } from 'react';
 
 import { getPortfolioCache } from '../../utils/cache';
@@ -74,146 +75,39 @@ export const usePortfolio: UsePortfolio = () => {
   const debouncedRefreshFromDB = useDebouncedFunction(refreshFromDB, 2000);
 
   useEffect(() => {
-    dbUtil(
-      Databases.ERC20TOKEN,
-      'emitter',
-      'on',
-      'insert',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.ERC20TOKEN,
-      'emitter',
-      'on',
-      'update',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.ERC20TOKEN,
-      'emitter',
-      'on',
-      'delete',
-      debouncedRefreshFromDB
-    );
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-insert`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-update`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-delete`, debouncedRefreshFromDB);
 
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', debouncedRefreshFromDB);
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', debouncedRefreshFromDB);
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'delete', debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.PRICE}-insert`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.PRICE}-update`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.PRICE}-delete`, debouncedRefreshFromDB);
 
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'insert', debouncedRefreshFromDB);
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'update', debouncedRefreshFromDB);
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'delete', debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.XPUB}-insert`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.XPUB}-update`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.XPUB}-delete`, debouncedRefreshFromDB);
 
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'insert',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'update',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'delete',
-      debouncedRefreshFromDB
-    );
-
+    ipcRenderer.on(`${Databases.TRANSACTION}-insert`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.TRANSACTION}-update`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.TRANSACTION}-delete`, debouncedRefreshFromDB);
+    
     return () => {
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'insert',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'update',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'delete',
-        debouncedRefreshFromDB
-      );
 
-      dbUtil(
-        Databases.PRICE,
-        'emitter',
-        'removeListener',
-        'insert',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.PRICE,
-        'emitter',
-        'removeListener',
-        'update',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.PRICE,
-        'emitter',
-        'oremoveListenern',
-        'delete',
-        debouncedRefreshFromDB
-      );
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-insert`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-update`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-delete`, debouncedRefreshFromDB);
 
-      dbUtil(
-        Databases.XPUB,
-        'emitter',
-        'removeListener',
-        'insert',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.XPUB,
-        'emitter',
-        'removeListener',
-        'update',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.XPUB,
-        'emitter',
-        'removeListener',
-        'delete',
-        debouncedRefreshFromDB
-      );
+      ipcRenderer.removeListener(`${Databases.PRICE}-insert`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.PRICE}-update`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.PRICE}-delete`, debouncedRefreshFromDB);
 
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'insert',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'update',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'delete',
-        debouncedRefreshFromDB
-      );
+      ipcRenderer.removeListener(`${Databases.XPUB}-insert`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.XPUB}-update`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.XPUB}-delete`, debouncedRefreshFromDB);
+      
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-insert`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-update`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-delete`, debouncedRefreshFromDB);
     };
   }, []);
 

--- a/cysync/src/store/hooks/useToken.ts
+++ b/cysync/src/store/hooks/useToken.ts
@@ -3,8 +3,9 @@ import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 
 import {
+  Databases,
+  dbUtil,
   ERC20Token,
-  erc20tokenDb,
   getLatestPriceForCoin,
   priceDb
 } from '../database';
@@ -42,17 +43,35 @@ export const useToken: UseToken = () => {
     priceDb.emitter.on('insert', onChange);
     priceDb.emitter.on('update', onChange);
 
-    erc20tokenDb.emitter.on('insert', onChange);
-    erc20tokenDb.emitter.on('update', onChange);
-    erc20tokenDb.emitter.on('delete', onChange);
+    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onChange);
+    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'update', onChange);
+    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onChange);
 
     return () => {
       priceDb.emitter.removeListener('insert', onChange);
       priceDb.emitter.removeListener('update', onChange);
 
-      erc20tokenDb.emitter.removeListener('insert', onChange);
-      erc20tokenDb.emitter.removeListener('update', onChange);
-      erc20tokenDb.emitter.removeListener('delete', onChange);
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'insert',
+        onChange
+      );
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'update',
+        onChange
+      );
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'delete',
+        onChange
+      );
     };
   }, []);
 
@@ -95,9 +114,14 @@ export const useToken: UseToken = () => {
   };
 
   const getAllTokensFromWallet = async (walletId: string, ethCoin: string) => {
-    const res = await erc20tokenDb.getByWalletId(walletId, ethCoin);
+    const res = await dbUtil(
+      Databases.ERC20TOKEN,
+      'getByWalletId',
+      walletId,
+      ethCoin
+    );
     const tokens: string[] = [];
-    res.forEach(coin => {
+    res.forEach((coin: { coin: string }) => {
       tokens.push(coin.coin);
     });
     setTokenList(tokens);

--- a/cysync/src/store/hooks/useToken.ts
+++ b/cysync/src/store/hooks/useToken.ts
@@ -1,5 +1,6 @@
 import { ALLCOINS as COINS } from '@cypherock/communication';
 import BigNumber from 'bignumber.js';
+import { ipcRenderer } from 'electron';
 import { useEffect, useState } from 'react';
 
 import {
@@ -39,38 +40,20 @@ export const useToken: UseToken = () => {
   const onChange = useDebouncedFunction(onDBChange, 800);
 
   useEffect(() => {
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', onChange);
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', onChange);
+    ipcRenderer.on(`${Databases.PRICE}-insert`, onChange);
+    ipcRenderer.on(`${Databases.PRICE}-update`, onChange);
 
-    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onChange);
-    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'update', onChange);
-    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onChange);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-insert`, onChange);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-update`, onChange);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-delete`, onChange);
 
     return () => {
-      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'insert', onChange);
-      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'update', onChange);
+      ipcRenderer.on(`${Databases.PRICE}-insert`, onChange);
+      ipcRenderer.removeListener(`${Databases.PRICE}-update`, onChange);
 
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'insert',
-        onChange
-      );
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'update',
-        onChange
-      );
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'delete',
-        onChange
-      );
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-insert`, onChange);
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-update`, onChange);
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-delete`, onChange);
     };
   }, []);
 

--- a/cysync/src/store/hooks/useToken.ts
+++ b/cysync/src/store/hooks/useToken.ts
@@ -6,8 +6,7 @@ import {
   Databases,
   dbUtil,
   ERC20Token,
-  getLatestPriceForCoin,
-  priceDb
+  getLatestPriceForCoin
 } from '../database';
 
 import { DisplayToken } from './types';
@@ -40,16 +39,16 @@ export const useToken: UseToken = () => {
   const onChange = useDebouncedFunction(onDBChange, 800);
 
   useEffect(() => {
-    priceDb.emitter.on('insert', onChange);
-    priceDb.emitter.on('update', onChange);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', onChange);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', onChange);
 
     dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onChange);
     dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'update', onChange);
     dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onChange);
 
     return () => {
-      priceDb.emitter.removeListener('insert', onChange);
-      priceDb.emitter.removeListener('update', onChange);
+      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'insert', onChange);
+      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'update', onChange);
 
       dbUtil(
         Databases.ERC20TOKEN,

--- a/cysync/src/store/hooks/useTransactionData.ts
+++ b/cysync/src/store/hooks/useTransactionData.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 
-import { transactionDb } from '../database';
+import { Databases, dbUtil } from '../database';
 
 import { DisplayTransaction } from './types';
 import { useDebouncedFunction } from './useDebounce';
@@ -64,14 +64,50 @@ export const useTransactionData: UseTransactionData = () => {
   );
 
   useEffect(() => {
-    transactionDb.emitter.on('insert', debouncedRefreshFromDB);
-    transactionDb.emitter.on('update', debouncedRefreshFromDB);
-    transactionDb.emitter.on('delete', debouncedRefreshFromDB);
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'insert',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'update',
+      debouncedRefreshFromDB
+    );
+    dbUtil(
+      Databases.TRANSACTION,
+      'emitter',
+      'on',
+      'delete',
+      debouncedRefreshFromDB
+    );
 
     return () => {
-      transactionDb.emitter.removeListener('insert', debouncedRefreshFromDB);
-      transactionDb.emitter.removeListener('update', debouncedRefreshFromDB);
-      transactionDb.emitter.removeListener('delete', debouncedRefreshFromDB);
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'insert',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'update',
+        debouncedRefreshFromDB
+      );
+      dbUtil(
+        Databases.TRANSACTION,
+        'emitter',
+        'removeListener',
+        'delete',
+        debouncedRefreshFromDB
+      );
     };
   }, []);
 

--- a/cysync/src/store/hooks/useTransactionData.ts
+++ b/cysync/src/store/hooks/useTransactionData.ts
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js';
+import { ipcRenderer } from 'electron';
 import { useEffect, useState } from 'react';
 
-import { Databases, dbUtil } from '../database';
+import { Databases } from '../database';
 
 import { DisplayTransaction } from './types';
 import { useDebouncedFunction } from './useDebounce';
@@ -64,50 +65,14 @@ export const useTransactionData: UseTransactionData = () => {
   );
 
   useEffect(() => {
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'insert',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'update',
-      debouncedRefreshFromDB
-    );
-    dbUtil(
-      Databases.TRANSACTION,
-      'emitter',
-      'on',
-      'delete',
-      debouncedRefreshFromDB
-    );
+    ipcRenderer.on(`${Databases.TRANSACTION}-insert`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.TRANSACTION}-update`, debouncedRefreshFromDB);
+    ipcRenderer.on(`${Databases.TRANSACTION}-delete`, debouncedRefreshFromDB);
 
     return () => {
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'insert',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'update',
-        debouncedRefreshFromDB
-      );
-      dbUtil(
-        Databases.TRANSACTION,
-        'emitter',
-        'removeListener',
-        'delete',
-        debouncedRefreshFromDB
-      );
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-insert`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-update`, debouncedRefreshFromDB);
+      ipcRenderer.removeListener(`${Databases.TRANSACTION}-delete`, debouncedRefreshFromDB);
     };
   }, []);
 

--- a/cysync/src/store/hooks/useWalletData.ts
+++ b/cysync/src/store/hooks/useWalletData.ts
@@ -2,13 +2,7 @@ import { ALLCOINS as COINS } from '@cypherock/communication';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 
-import {
-  Databases,
-  dbUtil,
-  getLatestPriceForCoin,
-  Xpub,
-  xpubDb
-} from '../database';
+import { Databases, dbUtil, getLatestPriceForCoin, Xpub } from '../database';
 
 import { DisplayCoin } from './types';
 import { useDebouncedFunction } from './useDebounce';
@@ -46,7 +40,7 @@ export const useWalletData: UseWalletData = () => {
   const [doRefresh, setDoRefresh] = useState(false);
 
   const insert = (coin: Xpub) => {
-    return xpubDb.insert(coin);
+    return dbUtil(Databases.XPUB, 'insert', coin);
   };
 
   const getCoinsWithPrices = async (coins: Xpub[]) => {
@@ -176,9 +170,13 @@ export const useWalletData: UseWalletData = () => {
 
   const getAllCoinsFromWallet = async () => {
     if (currentWalletId) {
-      const res = await xpubDb.getByWalletId(currentWalletId);
+      const res = await dbUtil(
+        Databases.XPUB,
+        'getByWalletId',
+        currentWalletId
+      );
       const coinList: string[] = [];
-      res.forEach(coin => {
+      res.forEach((coin: { coin: string }) => {
         coinList.push(coin.coin);
       });
       setCoinsPresent(coinList);
@@ -197,7 +195,7 @@ export const useWalletData: UseWalletData = () => {
       walletId,
       coinType: coin
     });
-    await xpubDb.delete(xpub, coin);
+    await dbUtil(Databases.XPUB, 'delete', xpub, coin);
     return getAllCoinsFromWallet();
   };
 
@@ -211,9 +209,9 @@ export const useWalletData: UseWalletData = () => {
     dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', onChange);
     dbUtil(Databases.PRICE, 'emitter', 'on', 'update', onChange);
 
-    xpubDb.emitter.on('insert', onChange);
-    xpubDb.emitter.on('update', onChange);
-    xpubDb.emitter.on('delete', onChange);
+    dbUtil(Databases.XPUB, 'emitter', 'on', 'insert', onChange);
+    dbUtil(Databases.XPUB, 'emitter', 'on', 'update', onChange);
+    dbUtil(Databases.XPUB, 'emitter', 'on', 'delete', onChange);
 
     return () => {
       dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'insert', onChange);
@@ -225,9 +223,9 @@ export const useWalletData: UseWalletData = () => {
         onChange
       );
 
-      xpubDb.emitter.removeListener('insert', onChange);
-      xpubDb.emitter.removeListener('update', onChange);
-      xpubDb.emitter.removeListener('delete', onChange);
+      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'insert', onChange);
+      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'update', onChange);
+      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'delete', onChange);
     };
   }, []);
 

--- a/cysync/src/store/hooks/useWalletData.ts
+++ b/cysync/src/store/hooks/useWalletData.ts
@@ -1,5 +1,6 @@
 import { ALLCOINS as COINS } from '@cypherock/communication';
 import BigNumber from 'bignumber.js';
+import { ipcRenderer } from 'electron';
 import { useEffect, useState } from 'react';
 
 import { Databases, dbUtil, getLatestPriceForCoin, Xpub } from '../database';
@@ -206,26 +207,19 @@ export const useWalletData: UseWalletData = () => {
   const onChange = useDebouncedFunction(onDBChange, 800);
 
   useEffect(() => {
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', onChange);
-    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', onChange);
+    ipcRenderer.on(`${Databases.PRICE}-insert`, onChange);
+    ipcRenderer.on(`${Databases.PRICE}-update`, onChange);
 
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'insert', onChange);
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'update', onChange);
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'delete', onChange);
-
+    ipcRenderer.on(`${Databases.XPUB}-insert`, onChange);
+    ipcRenderer.on(`${Databases.XPUB}-update`, onChange);
+    ipcRenderer.on(`${Databases.XPUB}-delete`, onChange);
     return () => {
-      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'insert', onChange);
-      dbUtil(
-        Databases.PRICE,
-        'emitter',
-        'oremoveListenern',
-        'update',
-        onChange
-      );
+      ipcRenderer.removeListener(`${Databases.PRICE}-insert`, onChange);
+      ipcRenderer.removeListener(`${Databases.PRICE}-update`, onChange);
 
-      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'insert', onChange);
-      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'update', onChange);
-      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'delete', onChange);
+      ipcRenderer.removeListener(`${Databases.XPUB}-insert`, onChange);
+      ipcRenderer.removeListener(`${Databases.XPUB}-update`, onChange);
+      ipcRenderer.removeListener(`${Databases.XPUB}-delete`, onChange);
     };
   }, []);
 

--- a/cysync/src/store/hooks/useWalletData.ts
+++ b/cysync/src/store/hooks/useWalletData.ts
@@ -6,7 +6,6 @@ import {
   Databases,
   dbUtil,
   getLatestPriceForCoin,
-  priceDb,
   Xpub,
   xpubDb
 } from '../database';
@@ -209,16 +208,22 @@ export const useWalletData: UseWalletData = () => {
   const onChange = useDebouncedFunction(onDBChange, 800);
 
   useEffect(() => {
-    priceDb.emitter.on('insert', onChange);
-    priceDb.emitter.on('update', onChange);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'insert', onChange);
+    dbUtil(Databases.PRICE, 'emitter', 'on', 'update', onChange);
 
     xpubDb.emitter.on('insert', onChange);
     xpubDb.emitter.on('update', onChange);
     xpubDb.emitter.on('delete', onChange);
 
     return () => {
-      priceDb.emitter.removeListener('insert', onChange);
-      priceDb.emitter.removeListener('update', onChange);
+      dbUtil(Databases.PRICE, 'emitter', 'removeListener', 'insert', onChange);
+      dbUtil(
+        Databases.PRICE,
+        'emitter',
+        'oremoveListenern',
+        'update',
+        onChange
+      );
 
       xpubDb.emitter.removeListener('insert', onChange);
       xpubDb.emitter.removeListener('update', onChange);

--- a/cysync/src/store/hooks/useWalletData.ts
+++ b/cysync/src/store/hooks/useWalletData.ts
@@ -3,7 +3,6 @@ import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 
 import {
-  addressDb,
   Databases,
   dbUtil,
   getLatestPriceForCoin,
@@ -194,7 +193,7 @@ export const useWalletData: UseWalletData = () => {
     coin: string,
     walletId: string
   ) => {
-    await addressDb.deleteAll({ xpub, coinType: coin });
+    await dbUtil(Databases.ADDRESS, 'deleteAll', { xpub, coinType: coin });
     await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
       walletId,
       coinType: coin

--- a/cysync/src/store/hooks/useWalletData.ts
+++ b/cysync/src/store/hooks/useWalletData.ts
@@ -4,9 +4,10 @@ import { useEffect, useState } from 'react';
 
 import {
   addressDb,
+  Databases,
+  dbUtil,
   getLatestPriceForCoin,
   priceDb,
-  receiveAddressDb,
   Xpub,
   xpubDb
 } from '../database';
@@ -194,7 +195,10 @@ export const useWalletData: UseWalletData = () => {
     walletId: string
   ) => {
     await addressDb.deleteAll({ xpub, coinType: coin });
-    await receiveAddressDb.deleteAll({ walletId, coinType: coin });
+    await dbUtil(Databases.RECEIVEADDRESS, 'deleteAll', {
+      walletId,
+      coinType: coin
+    });
     await xpubDb.delete(xpub, coin);
     return getAllCoinsFromWallet();
   };

--- a/cysync/src/store/provider/lockscreenProvider.tsx
+++ b/cysync/src/store/provider/lockscreenProvider.tsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import { loadDatabases } from '../../store/database';
 import {
   completeFirstBoot,
   isFirstBoot,
@@ -9,6 +8,7 @@ import {
   removePassword
 } from '../../utils/auth';
 import { getAutolockTime } from '../../utils/autolock';
+import { loadDatabases } from '../database';
 
 export interface LockscreenContextInterface {
   lockscreen: boolean;

--- a/cysync/src/store/provider/notificationProvider.tsx
+++ b/cysync/src/store/provider/notificationProvider.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 import logger from '../../utils/logger';
-import { Notification, notificationDb as NotificationDB } from '../database';
+import { Databases, dbUtil } from '../database';
 
 export interface NotificationContextInterface {
   data: Notification[];
@@ -31,7 +31,7 @@ export const NotificationProvider: React.FC = ({ children }) => {
   const markAllRead = async () => {
     try {
       logger.info('Marking all notifications as read');
-      await NotificationDB.markAllAsRead();
+      await dbUtil(Databases.NOTIFICATION, 'markAllAsRead');
       setHasUnread(false);
     } catch (error) {
       logger.error('Error in marking all notifications as read');
@@ -43,7 +43,11 @@ export const NotificationProvider: React.FC = ({ children }) => {
     setIsLoading(true);
     try {
       logger.info('Fetching latest notifications');
-      const res = await NotificationDB.getLatest(perPageLimit);
+      const res = await dbUtil(
+        Databases.NOTIFICATION,
+        'getLatest',
+        perPageLimit
+      );
       setNotifications(res.notifications);
       setHasNextPage(res.hasNext);
       setHasUnread(res.hasUnread);
@@ -64,7 +68,9 @@ export const NotificationProvider: React.FC = ({ children }) => {
       if (notifications.length > 0)
         lastNotif = notifications[notifications.length - 1];
 
-      const res = await NotificationDB.getAll(
+      const res = await dbUtil(
+        Databases.NOTIFICATION,
+        'getAll',
         lastNotif,
         notifications.length,
         perPageLimit

--- a/cysync/src/store/provider/socketProvider/index.tsx
+++ b/cysync/src/store/provider/socketProvider/index.tsx
@@ -7,7 +7,6 @@ import io, { Socket } from 'socket.io-client';
 import { deleteAllPortfolioCache } from '../../../utils/cache';
 import logger from '../../../utils/logger';
 import {
-  addressDb,
   Databases,
   dbUtil,
   transactionDb,
@@ -280,7 +279,9 @@ export const SocketProvider: React.FC = ({ children }) => {
                   addresses: [],
                   walletId: payload.walletId,
                   coinType: payload.coinType,
-                  addressDB: addressDb
+                  addressDbUtil: (...args: any) => {
+                    return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
+                  }
                 });
                 if (payload.tokenAbbr) {
                   addBalanceSyncItemFromXpub(xpub, {
@@ -401,7 +402,10 @@ export const SocketProvider: React.FC = ({ children }) => {
     let walletId: string | undefined;
     let xpub: string | undefined;
 
-    const addressDetailsList = await addressDb.getAll({ address, coinType });
+    const addressDetailsList = await dbUtil(Databases.ADDRESS, 'getAll', {
+      address,
+      coinType
+    });
     if (addressDetailsList && addressDetailsList.length > 0) {
       const addressDetails = addressDetailsList[0];
       if (addressDetails.xpub) {
@@ -509,7 +513,9 @@ export const SocketProvider: React.FC = ({ children }) => {
                 addresses: [],
                 walletId: address.walletId,
                 coinType: payload.coinType,
-                addressDB: addressDb
+                addressDbUtil: (...args: any) => {
+                  return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
+                }
               });
 
               if (isConfirmed) {

--- a/cysync/src/store/provider/socketProvider/index.tsx
+++ b/cysync/src/store/provider/socketProvider/index.tsx
@@ -8,7 +8,8 @@ import { deleteAllPortfolioCache } from '../../../utils/cache';
 import logger from '../../../utils/logger';
 import {
   addressDb,
-  receiveAddressDb,
+  Databases,
+  dbUtil,
   transactionDb,
   walletDb,
   xpubDb
@@ -204,8 +205,7 @@ export const SocketProvider: React.FC = ({ children }) => {
       }
     }
 
-    const allReceiveAddr = await receiveAddressDb.getAll();
-
+    const allReceiveAddr = await dbUtil(Databases.RECEIVEADDRESS, 'getAll');
     for (const receiveAddr of allReceiveAddr) {
       const coin = COINS[receiveAddr.coinType];
       if (coin && coin.isEth) {
@@ -240,7 +240,7 @@ export const SocketProvider: React.FC = ({ children }) => {
       }
     }
 
-    const allReceiveAddr = await receiveAddressDb.getAll();
+    const allReceiveAddr = await dbUtil(Databases.RECEIVEADDRESS, 'getAll');
 
     for (const receiveAddr of allReceiveAddr) {
       const coin = COINS[receiveAddr.coinType];

--- a/cysync/src/store/provider/socketProvider/index.tsx
+++ b/cysync/src/store/provider/socketProvider/index.tsx
@@ -6,13 +6,7 @@ import io, { Socket } from 'socket.io-client';
 
 import { deleteAllPortfolioCache } from '../../../utils/cache';
 import logger from '../../../utils/logger';
-import {
-  Databases,
-  dbUtil,
-  transactionDb,
-  walletDb,
-  xpubDb
-} from '../../database';
+import { Databases, dbUtil, transactionDb, xpubDb } from '../../database';
 import { useNetwork } from '../networkProvider';
 import { useSync } from '../syncProvider';
 
@@ -265,7 +259,11 @@ export const SocketProvider: React.FC = ({ children }) => {
         try {
           logger.info('Received receive txn hook', { payload });
           if (payload && payload.walletId && payload.coinType) {
-            const wallet = await walletDb.getByID(payload.walletId);
+            const wallet = await dbUtil(
+              Databases.WALLET,
+              'getByID',
+              payload.walletId
+            );
             if (wallet && wallet.length > 0) {
               const xpub = await xpubDb.getByWalletIdandCoin(
                 payload.walletId,

--- a/cysync/src/store/provider/syncProvider/index.tsx
+++ b/cysync/src/store/provider/syncProvider/index.tsx
@@ -26,11 +26,9 @@ import logger from '../../../utils/logger';
 import {
   Databases,
   dbUtil,
-  erc20tokenDb,
-  latestPriceDb,
-  priceDb,
   transactionDb,
-  xpubDb
+  xpubDb,
+  latestPriceDb
 } from '../../database';
 import { useNetwork } from '../networkProvider';
 import { useNotifications } from '../notificationProvider';
@@ -660,7 +658,7 @@ export const SyncProvider: React.FC = ({ children }) => {
       coin: item.coinType,
       days: item.days
     });
-    await priceDb.insert(item.coinType, item.days, res.data.data.entries);
+    await dbUtil(Databases.PRICE, 'insert', item.coinType, item.days, res.data.data.entries);
   };
 
   const executeLatestPriceItem = async (item: LatestPriceSyncItem) => {
@@ -930,7 +928,7 @@ export const SyncProvider: React.FC = ({ children }) => {
     module = 'default'
   }) => {
     const allXpubs = await xpubDb.getAll();
-    const tokens = await erc20tokenDb.getAll();
+    const tokens = await dbUtil(Databases.ERC20TOKEN, 'getAll');
 
     for (const xpub of allXpubs) {
       addLatestPriceSyncItemFromXpub(xpub, { isRefresh, module });

--- a/cysync/src/store/provider/syncProvider/index.tsx
+++ b/cysync/src/store/provider/syncProvider/index.tsx
@@ -23,13 +23,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 
 import logger from '../../../utils/logger';
-import {
-  Databases,
-  dbUtil
-} from '../../database';
-import {
-  latestPriceDb
-} from '../../database/databases';
+import { Databases, dbUtil } from '../../database';
 import { useNetwork } from '../networkProvider';
 import { useNotifications } from '../notificationProvider';
 
@@ -682,14 +676,25 @@ export const SyncProvider: React.FC = ({ children }) => {
       coin: item.coinType,
       days: item.days
     });
-    await dbUtil(Databases.PRICE, 'insert', item.coinType, item.days, res.data.data.entries);
+    await dbUtil(
+      Databases.PRICE,
+      'insert',
+      item.coinType,
+      item.days,
+      res.data.data.entries
+    );
   };
 
   const executeLatestPriceItem = async (item: LatestPriceSyncItem) => {
     const res = await pricingServer.getLatest({
       coin: item.coinType
     });
-    await latestPriceDb.insert(item.coinType, res.data.data.price);
+    await dbUtil(
+      Databases.LATESTPRICE,
+      'insert',
+      item.coinType,
+      res.data.data.price
+    );
   };
 
   const executeBalanceItem = async (item: BalanceSyncItem) => {
@@ -965,7 +970,7 @@ export const SyncProvider: React.FC = ({ children }) => {
     isRefresh = false,
     module = 'default'
   }) => {
-    const allXpubs = await xpubDb.getAll();
+    const allXpubs = await dbUtil(Databases.XPUB, 'getAll');
     const tokens = await dbUtil(Databases.ERC20TOKEN, 'getAll');
 
     for (const xpub of allXpubs) {

--- a/cysync/src/store/provider/syncProvider/index.tsx
+++ b/cysync/src/store/provider/syncProvider/index.tsx
@@ -622,13 +622,13 @@ export const SyncProvider: React.FC = ({ children }) => {
       }
 
       for (const tokenName of erc20Tokens) {
-        const token = await erc20tokenDb.getOne({
+        const token = await dbUtil(Databases.ERC20TOKEN, 'getOne', {
           walletId: item.walletId,
           coin: tokenName.toLowerCase(),
           ethCoin: item.coinType
         });
         if (!token) {
-          erc20tokenDb.insert({
+          dbUtil(Databases.ERC20TOKEN, 'insert', {
             walletId: item.walletId,
             coin: tokenName.toLowerCase(),
             ethCoin: item.coinType,
@@ -741,7 +741,9 @@ export const SyncProvider: React.FC = ({ children }) => {
             item.isRefresh
           );
           const balance = new BigNumber(balanceRes.data);
-          await erc20tokenDb.updateBalance(
+          await dbUtil(
+            Databases.ERC20TOKEN,
+            'updateBalance',
             item.coinType,
             item.walletId,
             balance.toString()
@@ -879,7 +881,7 @@ export const SyncProvider: React.FC = ({ children }) => {
     module = 'default'
   }) => {
     const allXpubs = await xpubDb.getAll();
-    const tokens = await erc20tokenDb.getAll();
+    const tokens = await dbUtil(Databases.ERC20TOKEN, 'getAll');
 
     for (const xpub of allXpubs) {
       addBalanceSyncItemFromXpub(xpub, { isRefresh, module });
@@ -909,7 +911,7 @@ export const SyncProvider: React.FC = ({ children }) => {
 
   const addPriceRefresh = async ({ isRefresh = false, module = 'default' }) => {
     const allXpubs = await xpubDb.getAll();
-    const tokens = await erc20tokenDb.getAll();
+    const tokens = await dbUtil(Databases.ERC20TOKEN, 'getAll');
 
     for (const xpub of allXpubs) {
       addPriceSyncItemFromXpub(xpub, { isRefresh, module });

--- a/cysync/src/store/provider/syncProvider/index.tsx
+++ b/cysync/src/store/provider/syncProvider/index.tsx
@@ -25,9 +25,11 @@ import React, { useEffect, useRef } from 'react';
 import logger from '../../../utils/logger';
 import {
   Databases,
-  dbUtil,
-  latestPriceDb
+  dbUtil
 } from '../../database';
+import {
+  latestPriceDb
+} from '../../database/databases';
 import { useNetwork } from '../networkProvider';
 import { useNotifications } from '../notificationProvider';
 

--- a/cysync/src/store/provider/syncProvider/index.tsx
+++ b/cysync/src/store/provider/syncProvider/index.tsx
@@ -24,7 +24,8 @@ import React, { useEffect, useRef } from 'react';
 
 import logger from '../../../utils/logger';
 import {
-  addressDb,
+  Databases,
+  dbUtil,
   erc20tokenDb,
   latestPriceDb,
   priceDb,
@@ -414,7 +415,9 @@ export const SyncProvider: React.FC = ({ children }) => {
                 : [],
               walletId: item.walletId,
               coinType: item.coinType,
-              addressDB: addressDb,
+              addressDbUtil: (...args: any) => {
+                return dbUtil(Databases.ADDRESS, args[0], ...args.slice(1));
+              },
               walletName: item.walletName
             });
             // No need to retry if the inserting fails because it'll produce the same error.

--- a/cysync/src/store/provider/walletsProvider.tsx
+++ b/cysync/src/store/provider/walletsProvider.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import logger from '../../utils/logger';
-import { erc20tokenDb, walletDb, xpubDb } from '../database';
+import { Databases, dbUtil, walletDb, xpubDb } from '../database';
 
 export interface Coin {
   name: string;
@@ -61,7 +61,7 @@ export const WalletsProvider: React.FC = ({ children }) => {
 
     try {
       const xpubRes = await xpubDb.getAll();
-      const erc20Res = await erc20tokenDb.getAll();
+      const erc20Res = await dbUtil(Databases.ERC20TOKEN, 'getAll');
       const coinTypeList = new Set<string>();
       for (const xpub of xpubRes) {
         coinTypeList.add(xpub.coin);
@@ -108,8 +108,8 @@ export const WalletsProvider: React.FC = ({ children }) => {
     xpubDb.emitter.on('insert', onUpdate);
     xpubDb.emitter.on('delete', onUpdate);
 
-    erc20tokenDb.emitter.on('insert', onUpdate);
-    erc20tokenDb.emitter.on('delete', onUpdate);
+    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onUpdate);
+    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onUpdate);
 
     return () => {
       logger.verbose('Removed all wallet & xpub DB listners.');
@@ -120,8 +120,20 @@ export const WalletsProvider: React.FC = ({ children }) => {
       xpubDb.emitter.removeListener('insert', onUpdate);
       xpubDb.emitter.removeListener('delete', onUpdate);
 
-      erc20tokenDb.emitter.removeListener('insert', onUpdate);
-      erc20tokenDb.emitter.removeListener('delete', onUpdate);
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'insert',
+        onUpdate
+      );
+      dbUtil(
+        Databases.ERC20TOKEN,
+        'emitter',
+        'removeListener',
+        'delete',
+        onUpdate
+      );
     };
   }, []);
 

--- a/cysync/src/store/provider/walletsProvider.tsx
+++ b/cysync/src/store/provider/walletsProvider.tsx
@@ -1,4 +1,5 @@
 import { ALLCOINS as COINS } from '@cypherock/communication';
+import { ipcRenderer } from 'electron';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
@@ -101,39 +102,27 @@ export const WalletsProvider: React.FC = ({ children }) => {
   useEffect(() => {
     logger.verbose('Adding all wallet & xpub DB listners.');
 
-    dbUtil(Databases.WALLET, 'emitter', 'on', 'insert', onUpdate);
-    dbUtil(Databases.WALLET, 'emitter', 'on', 'update', onUpdate);
-    dbUtil(Databases.WALLET, 'emitter', 'on', 'delete', onUpdate);
+    ipcRenderer.on(`${Databases.WALLET}-insert`, onUpdate);
+    ipcRenderer.on(`${Databases.WALLET}-update`, onUpdate);
+    ipcRenderer.on(`${Databases.WALLET}-delete`, onUpdate);
 
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'insert', onUpdate);
-    dbUtil(Databases.XPUB, 'emitter', 'on', 'delete', onUpdate);
+    ipcRenderer.on(`${Databases.XPUB}-insert`, onUpdate);
+    ipcRenderer.on(`${Databases.XPUB}-delete`, onUpdate);
 
-    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onUpdate);
-    dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onUpdate);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-insert`, onUpdate);
+    ipcRenderer.on(`${Databases.ERC20TOKEN}-delete`, onUpdate);
 
     return () => {
-      logger.verbose('Removed all wallet & xpub DB listners.');
-      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'insert', onUpdate);
-      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'update', onUpdate);
-      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'delete', onUpdate);
+      logger.verbose('Removing all wallet & xpub DB listners.');
+      ipcRenderer.removeListener(`${Databases.WALLET}-insert`, onUpdate);
+      ipcRenderer.removeListener(`${Databases.WALLET}-update`, onUpdate);
+      ipcRenderer.removeListener(`${Databases.WALLET}-delete`, onUpdate);
 
-      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'insert', onUpdate);
-      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'delete', onUpdate);
+      ipcRenderer.removeListener(`${Databases.XPUB}-insert`, onUpdate);
+      ipcRenderer.removeListener(`${Databases.XPUB}-delete`, onUpdate);
 
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'insert',
-        onUpdate
-      );
-      dbUtil(
-        Databases.ERC20TOKEN,
-        'emitter',
-        'removeListener',
-        'delete',
-        onUpdate
-      );
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-insert`, onUpdate);
+      ipcRenderer.removeListener(`${Databases.ERC20TOKEN}-delete`, onUpdate);
     };
   }, []);
 

--- a/cysync/src/store/provider/walletsProvider.tsx
+++ b/cysync/src/store/provider/walletsProvider.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import logger from '../../utils/logger';
-import { Databases, dbUtil, xpubDb } from '../database';
+import { Databases, dbUtil } from '../database';
 
 export interface Coin {
   name: string;
@@ -60,7 +60,7 @@ export const WalletsProvider: React.FC = ({ children }) => {
     }
 
     try {
-      const xpubRes = await xpubDb.getAll();
+      const xpubRes = await dbUtil(Databases.XPUB, 'getAll');
       const erc20Res = await dbUtil(Databases.ERC20TOKEN, 'getAll');
       const coinTypeList = new Set<string>();
       for (const xpub of xpubRes) {
@@ -105,8 +105,8 @@ export const WalletsProvider: React.FC = ({ children }) => {
     dbUtil(Databases.WALLET, 'emitter', 'on', 'update', onUpdate);
     dbUtil(Databases.WALLET, 'emitter', 'on', 'delete', onUpdate);
 
-    xpubDb.emitter.on('insert', onUpdate);
-    xpubDb.emitter.on('delete', onUpdate);
+    dbUtil(Databases.XPUB, 'emitter', 'on', 'insert', onUpdate);
+    dbUtil(Databases.XPUB, 'emitter', 'on', 'delete', onUpdate);
 
     dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'insert', onUpdate);
     dbUtil(Databases.ERC20TOKEN, 'emitter', 'on', 'delete', onUpdate);
@@ -117,8 +117,8 @@ export const WalletsProvider: React.FC = ({ children }) => {
       dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'update', onUpdate);
       dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'delete', onUpdate);
 
-      xpubDb.emitter.removeListener('insert', onUpdate);
-      xpubDb.emitter.removeListener('delete', onUpdate);
+      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'insert', onUpdate);
+      dbUtil(Databases.XPUB, 'emitter', 'removeListener', 'delete', onUpdate);
 
       dbUtil(
         Databases.ERC20TOKEN,

--- a/cysync/src/store/provider/walletsProvider.tsx
+++ b/cysync/src/store/provider/walletsProvider.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import logger from '../../utils/logger';
-import { Databases, dbUtil, walletDb, xpubDb } from '../database';
+import { Databases, dbUtil, xpubDb } from '../database';
 
 export interface Coin {
   name: string;
@@ -42,7 +42,7 @@ export const WalletsProvider: React.FC = ({ children }) => {
   const getAll = async () => {
     try {
       logger.verbose('Getting all wallets and xpub data');
-      const walletRes = await walletDb.getAll();
+      const walletRes = await dbUtil(Databases.WALLET, 'getAll');
 
       if (walletRes.length !== 0) setAllWallets(walletRes);
       else {
@@ -101,9 +101,9 @@ export const WalletsProvider: React.FC = ({ children }) => {
   useEffect(() => {
     logger.verbose('Adding all wallet & xpub DB listners.');
 
-    walletDb.emitter.on('insert', onUpdate);
-    walletDb.emitter.on('update', onUpdate);
-    walletDb.emitter.on('delete', onUpdate);
+    dbUtil(Databases.WALLET, 'emitter', 'on', 'insert', onUpdate);
+    dbUtil(Databases.WALLET, 'emitter', 'on', 'update', onUpdate);
+    dbUtil(Databases.WALLET, 'emitter', 'on', 'delete', onUpdate);
 
     xpubDb.emitter.on('insert', onUpdate);
     xpubDb.emitter.on('delete', onUpdate);
@@ -113,9 +113,9 @@ export const WalletsProvider: React.FC = ({ children }) => {
 
     return () => {
       logger.verbose('Removed all wallet & xpub DB listners.');
-      walletDb.emitter.removeListener('insert', onUpdate);
-      walletDb.emitter.removeListener('update', onUpdate);
-      walletDb.emitter.removeListener('delete', onUpdate);
+      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'insert', onUpdate);
+      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'update', onUpdate);
+      dbUtil(Databases.WALLET, 'emitter', 'removeListener', 'delete', onUpdate);
 
       xpubDb.emitter.removeListener('insert', onUpdate);
       xpubDb.emitter.removeListener('delete', onUpdate);

--- a/cysync/src/utils/auth.ts
+++ b/cysync/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcrypt';
 import crypto from 'crypto';
 
-import { passEnDb, Databases, dbUtil, Xpub } from '../store/database';
+import { Databases, dbUtil, Xpub } from '../store/database';
 
 export const bcryptPass = (pass: string): string => {
   return bcrypt.hashSync(pass, 16);
@@ -77,7 +77,7 @@ export const resetDesktopApplication = (): void => {
 export const passChangeEffect = async (singleHash: string) => {
   const outputsXpubs: Xpub[] = await dbUtil(Databases.XPUB, 'getAll');
 
-  passEnDb.setPassHash(singleHash); //ensure this is cleared once wallet/xpub object are destroyed.
+  dbUtil(Databases.PASSEN, 'setPassHash', singleHash); //ensure this is cleared once wallet/xpub object are destroyed.
 
   await dbUtil(Databases.XPUB, 'updateAll', outputsXpubs);
 

--- a/cysync/src/utils/auth.ts
+++ b/cysync/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcrypt';
 import crypto from 'crypto';
 
-import { passEnDb, Xpub, xpubDb } from '../store/database';
+import { passEnDb, Databases, dbUtil, Xpub } from '../store/database';
 
 export const bcryptPass = (pass: string): string => {
   return bcrypt.hashSync(pass, 16);
@@ -75,13 +75,11 @@ export const resetDesktopApplication = (): void => {
  * @param singleHash
  */
 export const passChangeEffect = async (singleHash: string) => {
-  let outputsXpubs: Xpub[];
-
-  outputsXpubs = await xpubDb.getAll();
+  const outputsXpubs: Xpub[] = await dbUtil(Databases.XPUB, 'getAll');
 
   passEnDb.setPassHash(singleHash); //ensure this is cleared once wallet/xpub object are destroyed.
 
-  await xpubDb.updateAll(outputsXpubs);
+  await dbUtil(Databases.XPUB, 'updateAll', outputsXpubs);
 
   outputsXpubs.splice(0, outputsXpubs.length);
 };


### PR DESCRIPTION
### What?
Moving database to Main Process. So instead of the renderer process calling the db, the main process would be making the calls
### Why?
Previously NEDB was using indexedDB to store the database which was logging raw data on places that was causing trouble. So we are moving the database calls to the main process so NEDB automatically stores them as files rather than using indexedDB
### How?
It is made possible through the ipc calls [ipcMain](https://www.electronjs.org/docs/latest/api/ipc-main) & [ipcRenderer](https://www.electronjs.org/docs/latest/api/ipc-renderer).  
So now the browser client emits a `database` event with a payload that in turn makes the db call in the main process. Then the results from the main process is sent back to the renderer process.

### Evidences
> Databases stored as files
<img width="427" alt="image" src="https://user-images.githubusercontent.com/102788106/161919508-2da6dd19-dc6e-45e3-bbd3-35afc40bbad0.png">

### Work in progress
- [X] Notifications DB
- [X] Device DB
- [X] Price DB
- [X] Xpub DB
- [X] Transaction DB
- [X] Wallet DB
- [X] ERC20Token DB
- [X] Address DB
- [X] Receive Address DB

### Linked PRs
- [Protocols](https://github.com/Cypherock/cysync-module-protocols/pull/1)
- [Wallet](https://github.com/Cypherock/cysync-module-wallet/pull/1)
- [Database](https://github.com/Cypherock/cysync-module-database/pull/2)