### PR TITLE
selectively resolve appdmg dependency

### DIFF
--- a/cysync/package.json
+++ b/cysync/package.json
@@ -131,5 +131,8 @@
     "*.{js,jsx,json,md,html,css}": [
       "prettier --write"
     ]
+  },
+  "resolutions": {
+    "**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg": "^0.6.4"
   }
 }

--- a/cysync/package.json
+++ b/cysync/package.json
@@ -131,8 +131,5 @@
     "*.{js,jsx,json,md,html,css}": [
       "prettier --write"
     ]
-  },
-  "resolutions": {
-    "**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg": "^0.6.4"
   }
 }

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
 const childProcess = require("child_process");
 
 const BRANCH_OR_TAG = process.env.GITHUB_REF_TYPE;
@@ -63,7 +64,7 @@ const setConfig = (buildType) => {
   const configPath = path.join(__dirname, "..", "cysync", "src", "config.json");
   fs.writeFileSync(
     configPath,
-    JSON.stringify(BUILD_TYPE_CONFIG[buildType], undefined, 2)
+    JSON.stringify(BUILD_TYPE_CONFIG[buildType], undefined, 2) + os.EOL
   );
 };
 
@@ -133,16 +134,20 @@ const setVersion = async (buildType, tagName) => {
 };
 
 const setDependencies = () => {
-  const packageJsonPath = path.join(__dirname, "..", "cysync", "package.json");
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
-
   if (process.platform === "darwin") {
-    packageJson.resolutions = {
-      "**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg": "^0.6.4"
-    }
-  }
+    const packageJsonPath = path.join(__dirname, "..", "cysync", "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
 
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
+    if (packageJson.hasOwnProperty("resolutions")) {
+      packageJson.resolutions["**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg"] = "^0.6.4";
+    } else {
+      packageJson.resolutions = {
+        "**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg": "^0.6.4"
+      };
+    }
+
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2) + os.EOL);
+  }
 }
 
 const run = async () => {

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -132,11 +132,25 @@ const setVersion = async (buildType, tagName) => {
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
 };
 
+const setDependencies = () => {
+  const packageJsonPath = path.join(__dirname, "..", "cysync", "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+
+  if (process.platform === "darwin") {
+    packageJson.resolutions = {
+      "**/@electron-forge/maker-dmg/electron-installer-dmg/appdmg": "^0.6.4"
+    }
+  }
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
+}
+
 const run = async () => {
   try {
     const { buildType, tagName } = getArgs();
     setConfig(buildType);
     await setVersion(buildType, tagName);
+    setDependencies();
   } catch (error) {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
Building for M1 Mac chips fails due to a dependency on package appdmg. Need to override that. 
More details on this [issue](https://github.com/LinusU/node-appdmg/issues/204)
