### PR TITLE
CSI-1099 improve gas slider to handle lower medium fees

### DIFF
--- a/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Recipient.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Recipient.tsx
@@ -383,8 +383,8 @@ const Recipient: React.FC<StepComponentProps> = props => {
   const { deviceConnection, deviceSdkVersion, beforeFlowStart, setIsInFlow } =
     useConnection();
 
-  const intTransactionFee = parseInt(transactionFee, 10) || 0;
-  const [mediumFee, setMediumFee] = useState(intTransactionFee);
+  const floatTransactionFee = parseFloat(transactionFee) || 0;
+  const [mediumFee, setMediumFee] = useState(floatTransactionFee);
   const [isMediumFeeLoading, setIsMediumFeeLoading] = useState(false);
   const [mediumFeeError, setMediumFeeError] = useState(false);
 
@@ -404,6 +404,7 @@ const Recipient: React.FC<StepComponentProps> = props => {
     return prevInfo[coinDetails.slug];
   };
 
+  // TODO: This parameter should be dynamic as it depends on the coin and network congestion
   const lowFeePercentage = 0.5;
 
   // Stores mediumFee for the coin in localStorage
@@ -510,7 +511,7 @@ const Recipient: React.FC<StepComponentProps> = props => {
           coinDetails.slug,
           token
         ),
-        fees: intTransactionFee,
+        fees: floatTransactionFee,
         isSendAll: maxSend,
         data: {
           gasLimit,
@@ -557,7 +558,7 @@ const Recipient: React.FC<StepComponentProps> = props => {
           <CustomSlider
             handleTransactionFeeChangeSlider={handleTransactionFeeChangeSlider}
             mediumFee={mediumFee}
-            fee={intTransactionFee}
+            fee={floatTransactionFee}
           />
           {mediumFeeError && getFeeErrorInfo()}
         </>
@@ -777,7 +778,7 @@ const Recipient: React.FC<StepComponentProps> = props => {
           </Typography>
         </div>
         {getFeeInput()}
-        {intTransactionFee < lowFeePercentage * mediumFee && (
+        {floatTransactionFee < lowFeePercentage * mediumFee && (
           <div style={{ textAlign: 'center' }}>
             <Typography
               className="text"

--- a/cysync/src/pages/mainApp/sidebar/wallet/send/generalComponents/CustomSlider.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/send/generalComponents/CustomSlider.tsx
@@ -144,6 +144,8 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
     handleTransactionFeeChangeSlider(v);
   };
 
+  const step = mediumFee < 5 ? 0.1 : 0.2;
+
   return (
     <Root className={classes.root}>
       <div className={classes.labels}>
@@ -154,9 +156,9 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
       <IOSSlider
         aria-label="ios slider"
         value={fee}
-        min={1}
+        min={0}
         max={mediumFee * 2}
-        step={1}
+        step={step} // number of steps is dynamically calculated based on the mediumFee
         onChange={handleChange}
         valueLabelDisplay={valueLabelDisplay}
         valueLabelFormat={valueLabelFormat}


### PR DESCRIPTION
The current step count 0.2, inspired from Ledger. Due to it, the sliding is smooth
For lower values less than 5, the step count will be 0.1 to improve the experience