### PR TITLE
added cache folder for webpack-asset-relocater-loader

### DIFF
--- a/cysync/webpack.plugins.js
+++ b/cysync/webpack.plugins.js
@@ -1,7 +1,18 @@
 const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const relocateLoader = require('@vercel/webpack-asset-relocator-loader');
 
 module.exports = [
   new ForkTsCheckerWebpackPlugin(),
-  new webpack.IgnorePlugin({ resourceRegExp: /osx-temperature-sensor/ })
+  new webpack.IgnorePlugin({ resourceRegExp: /osx-temperature-sensor/ }),
+  {
+    apply(compiler) {
+      compiler.hooks.compilation.tap(
+        'webpack-asset-relocator-loader',
+        compilation => {
+          relocateLoader.initAssetCache(compilation, 'native_modules');
+        }
+      );
+    }
+  }
 ];


### PR DESCRIPTION
When using Webpack 5 caching, asset permissions need to be maintained through their own cache, and the public path needs to be injected into the build.


[reference](https://github.com/vercel/webpack-asset-relocator-loader#caching)