### PR TITLE
Revisit and fix issues

### DIFF
--- a/cysync/src/errors/error.ts
+++ b/cysync/src/errors/error.ts
@@ -7,14 +7,27 @@ class DisplayError {
     this.code = code;
     this.message = message;
   }
+  /**
+   * used to display errors to the user
+   * @returns formatted error string
+   */
+  public showError() {
+    if (this.isSet) return this.getCode() + ' : ' + this.getMessage();
+    return '';
+  }
+  /**
+   * Use this only when the error message text is needed
+   * @returns error message
+   */
   public getMessage() {
     return this.message || '';
   }
+  /**
+   * Use this only when the error code is needed
+   * @returns error code
+   */
   public getCode() {
     return this.code || '';
-  }
-  public showError() {
-    return this.getCode() + ' : ' + this.getMessage();
   }
 }
 /* tslint:disable-next-line */

--- a/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/cardAuthentication.tsx
+++ b/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/cardAuthentication.tsx
@@ -1,9 +1,9 @@
 import ReportIcon from '@mui/icons-material/Report';
-import { IconButton } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import success from '../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../designSystem/designComponents/buttons/button';
@@ -77,6 +77,13 @@ const CardAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
     errorObj,
     setCardsStatus
   } = useCardAuth(true);
+
+  const { deviceConnection } = useConnection();
+  const latestDeviceConnection = useRef<any>();
+
+  useEffect(() => {
+    latestDeviceConnection.current = deviceConnection;
+  }, [deviceConnection]);
 
   useEffect(() => {
     Analytics.Instance.event(
@@ -207,16 +214,31 @@ const CardAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
               </div>
             )}
             <div className={classes.btnContainer}>
-              {showRetry && (
-                <CustomButton
-                  onClick={() => {
-                    onRetry();
-                  }}
-                  style={{ margin: '1rem 10px 1rem 0' }}
-                >
-                  Retry
-                </CustomButton>
-              )}
+              {showRetry &&
+                (!latestDeviceConnection.current ? (
+                  <Tooltip
+                    title={'Reconnect the device to retry'}
+                    placement="top"
+                  >
+                    <div>
+                      <CustomButton
+                        color="primary"
+                        style={{ margin: '1rem 10px 1rem 0' }}
+                        disabled
+                      >
+                        Retry
+                      </CustomButton>
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <CustomButton
+                    color="primary"
+                    onClick={onRetry}
+                    style={{ margin: '1rem 10px 1rem 0' }}
+                  >
+                    Retry
+                  </CustomButton>
+                ))}
               <CustomButton
                 onClick={handleFeedbackOpen}
                 style={{ margin: '1rem 0rem' }}

--- a/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
@@ -10,7 +10,6 @@ import CustomButton from '../../../../../designSystem/designComponents/buttons/b
 import AvatarIcon from '../../../../../designSystem/designComponents/icons/AvatarIcon';
 import Icon from '../../../../../designSystem/designComponents/icons/Icon';
 import ErrorExclamation from '../../../../../designSystem/iconGroups/errorExclamation';
-import { CyError } from '../../../../../errors';
 import { useDeviceAuth } from '../../../../../store/hooks/flows';
 import {
   DeviceConnectionState,

--- a/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
@@ -98,7 +98,7 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
     completed,
     errorObj,
     confirmed,
-    setErrorObj
+    clearErrorObj
   } = useDeviceAuth(true);
 
   const feedback = useFeedback();
@@ -196,7 +196,7 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
   const timeout = React.useRef<NodeJS.Timeout | undefined>(undefined);
   const onRetry = () => {
     setErrorMsg('');
-    setErrorObj(new CyError());
+    clearErrorObj();
     resetHooks();
 
     if (timeout.current) {

--- a/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/initialApp/deviceFlow/deviceSetup/stepperFormComponents/deviceAuth.tsx
@@ -1,9 +1,9 @@
 import ReportIcon from '@mui/icons-material/Report';
-import { IconButton } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import success from '../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../designSystem/designComponents/buttons/button';
@@ -83,6 +83,11 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
     deviceConnectionState,
     setIsInFlow
   } = useConnection();
+  const latestDeviceConnection = useRef<any>();
+
+  useEffect(() => {
+    latestDeviceConnection.current = deviceConnection;
+  }, [deviceConnection]);
   const [errorMsg, setErrorMsg] = React.useState('');
   const [initialStart, setInitialStart] = React.useState(false);
 
@@ -266,16 +271,29 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({ handleNext }) => {
               </Typography>
             </div>
             <div className={classes.btnContainer}>
-              {verified !== -1 && (
-                <CustomButton
-                  onClick={() => {
-                    onRetry();
-                  }}
-                  style={{ margin: '1rem 10px 1rem 0' }}
-                >
-                  Retry
-                </CustomButton>
-              )}
+              {verified !== -1 &&
+                (!latestDeviceConnection.current ? (
+                  <Tooltip
+                    title={'Reconnect the device to retry'}
+                    placement="top"
+                  >
+                    <div>
+                      <CustomButton
+                        style={{ margin: '1rem 10px 1rem 0' }}
+                        disabled
+                      >
+                        Retry
+                      </CustomButton>
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <CustomButton
+                    onClick={onRetry}
+                    style={{ margin: '1rem 10px 1rem 0' }}
+                  >
+                    Retry
+                  </CustomButton>
+                ))}
               <CustomButton
                 onClick={() => {
                   feedback.showFeedback({ isContact: true });

--- a/cysync/src/pages/mainApp/deviceUpdater/authenticator.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/authenticator.tsx
@@ -1,4 +1,5 @@
 import AlertIcon from '@mui/icons-material/ReportProblemOutlined';
+import { Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import ListItem from '@mui/material/ListItem';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
@@ -235,15 +236,25 @@ const Authenticator: React.FC<Props> = ({ handleClose }) => {
                   >
                     Close
                   </CustomButton>
-                  <CustomButton
-                    disabled={!(deviceConnection && firmwareVersion)}
-                    onClick={() => {
-                      startDeviceAuth();
-                    }}
-                    style={{ margin: '1rem 0rem' }}
-                  >
-                    Retry
-                  </CustomButton>
+                  {!(deviceConnection && firmwareVersion) ? (
+                    <Tooltip
+                      title={'Reconnect the device to retry'}
+                      placement="top"
+                    >
+                      <div>
+                        <CustomButton style={{ margin: '1rem 0rem' }} disabled>
+                          Retry
+                        </CustomButton>
+                      </div>
+                    </Tooltip>
+                  ) : (
+                    <CustomButton
+                      onClick={startDeviceAuth}
+                      style={{ margin: '1rem 0rem' }}
+                    >
+                      Retry
+                    </CustomButton>
+                  )}
                   <CustomButton
                     onClick={handleFeedbackOpen}
                     style={{ margin: '1rem 0rem' }}

--- a/cysync/src/pages/mainApp/deviceUpdater/index.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/index.tsx
@@ -55,14 +55,14 @@ const DeviceUpdatePopup = () => {
           Analytics.Actions.OPEN
         );
         logger.info('Redirecting user to device update settings page');
-        return navigate(Routes.settings.device.upgrade);
+        return navigate(`${Routes.settings.device.upgrade}?isRefresh=true`);
       } else if (localUpdateType === 'auth') {
         Analytics.Instance.event(
           Analytics.Categories.DEVICE_AUTH_PROMPT,
           Analytics.Actions.OPEN
         );
         logger.info('Redirecting user to device auth settings page');
-        return navigate(Routes.settings.device.auth);
+        return navigate(`${Routes.settings.device.auth}?isRefresh=true`);
       } else {
         Analytics.Instance.event(
           Analytics.Categories.INITIAL_FLOW_IN_MAIN,

--- a/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/cardAuthentication.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/cardAuthentication.tsx
@@ -1,9 +1,9 @@
 import ReportIcon from '@mui/icons-material/Report';
-import { IconButton } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import success from '../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../designSystem/designComponents/buttons/button';
@@ -68,7 +68,12 @@ const CardAuthentication: React.FC<StepComponentProps> = ({
   handleNext,
   handleClose
 }) => {
-  const { connected } = useConnection();
+  const { connected, deviceConnection } = useConnection();
+  const latestDeviceConnection = useRef<any>();
+
+  useEffect(() => {
+    latestDeviceConnection.current = deviceConnection;
+  }, [deviceConnection]);
 
   const {
     handleFeedbackOpen,
@@ -218,16 +223,30 @@ const CardAuthentication: React.FC<StepComponentProps> = ({
               >
                 Close
               </CustomButton>
-              {showRetry && (
-                <CustomButton
-                  onClick={() => {
-                    onRetry();
-                  }}
-                  style={{ margin: '1rem 10px 1rem 0' }}
-                >
-                  Retry
-                </CustomButton>
-              )}
+
+              {showRetry &&
+                (!latestDeviceConnection.current ? (
+                  <Tooltip
+                    title={'Reconnect the device to retry'}
+                    placement="top"
+                  >
+                    <div>
+                      <CustomButton
+                        style={{ margin: '1rem 10px 1rem 0' }}
+                        disabled
+                      >
+                        Retry
+                      </CustomButton>
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <CustomButton
+                    onClick={onRetry}
+                    style={{ margin: '1rem 10px 1rem 0' }}
+                  >
+                    Retry
+                  </CustomButton>
+                ))}
               <CustomButton
                 onClick={handleFeedbackOpen}
                 style={{ margin: '1rem 0rem' }}

--- a/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
@@ -10,7 +10,6 @@ import CustomButton from '../../../../../designSystem/designComponents/buttons/b
 import AvatarIcon from '../../../../../designSystem/designComponents/icons/AvatarIcon';
 import Icon from '../../../../../designSystem/designComponents/icons/Icon';
 import ErrorExclamation from '../../../../../designSystem/iconGroups/errorExclamation';
-import { CyError } from '../../../../../errors';
 import { useDeviceAuth } from '../../../../../store/hooks/flows';
 import {
   DeviceConnectionState,

--- a/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
@@ -1,9 +1,9 @@
 import ReportIcon from '@mui/icons-material/Report';
-import { IconButton } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import success from '../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../designSystem/designComponents/buttons/button';
@@ -84,6 +84,12 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({
     deviceConnectionState,
     setIsInFlow
   } = useConnection();
+  const latestDeviceConnection = useRef<any>();
+
+  useEffect(() => {
+    latestDeviceConnection.current = deviceConnection;
+  }, [deviceConnection]);
+
   const [errorMsg, setErrorMsg] = React.useState('');
   const [initialStart, setInitialStart] = React.useState(false);
 
@@ -253,16 +259,29 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({
               >
                 Close
               </CustomButton>
-              {verified !== -1 && (
-                <CustomButton
-                  onClick={() => {
-                    onRetry();
-                  }}
-                  style={{ margin: '1rem 10px 1rem 0' }}
-                >
-                  Retry
-                </CustomButton>
-              )}
+              {verified !== -1 &&
+                (!latestDeviceConnection.current ? (
+                  <Tooltip
+                    title={'Reconnect the device to retry'}
+                    placement="top"
+                  >
+                    <div>
+                      <CustomButton
+                        style={{ margin: '1rem 10px 1rem 0' }}
+                        disabled
+                      >
+                        Retry
+                      </CustomButton>
+                    </div>
+                  </Tooltip>
+                ) : (
+                  <CustomButton
+                    onClick={onRetry}
+                    style={{ margin: '1rem 10px 1rem 0' }}
+                  >
+                    Retry
+                  </CustomButton>
+                ))}
               <CustomButton
                 onClick={handleFeedbackOpen}
                 style={{ margin: '1rem 0rem' }}

--- a/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/initialFlow/stepperFormComponents/deviceAuth.tsx
@@ -101,7 +101,7 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({
     errorObj,
     confirmed,
     handleFeedbackOpen,
-    setErrorObj
+    clearErrorObj
   } = useDeviceAuth(true);
 
   useEffect(() => {
@@ -176,7 +176,7 @@ const DeviceAuthentication: React.FC<StepComponentProps> = ({
   const timeout = React.useRef<NodeJS.Timeout | undefined>(undefined);
   const onRetry = () => {
     setErrorMsg('');
-    setErrorObj(new CyError());
+    clearErrorObj();
     resetHooks();
 
     if (timeout.current) {

--- a/cysync/src/pages/mainApp/deviceUpdater/updater.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/updater.tsx
@@ -14,7 +14,6 @@ import CustomButton from '../../../designSystem/designComponents/buttons/button'
 import ModAvatar from '../../../designSystem/designComponents/icons/AvatarIcon';
 import Icon from '../../../designSystem/designComponents/icons/Icon';
 import ErrorExclamation from '../../../designSystem/iconGroups/errorExclamation';
-import { CyError } from '../../../errors';
 import { useDeviceUpgrade } from '../../../store/hooks/flows';
 import { useNetwork } from '../../../store/provider';
 import Analytics from '../../../utils/analytics';

--- a/cysync/src/pages/mainApp/deviceUpdater/updater.tsx
+++ b/cysync/src/pages/mainApp/deviceUpdater/updater.tsx
@@ -96,7 +96,7 @@ const Updater: React.FC<Props> = ({ handleClose }) => {
     latestVersion,
     handleFeedbackOpen,
     errorObj,
-    setErrorObj
+    clearErrorObj
   } = useDeviceUpgrade();
 
   const onClose = () => {
@@ -106,7 +106,7 @@ const Updater: React.FC<Props> = ({ handleClose }) => {
 
   useEffect(() => {
     logger.info('Initiating device update from prompt');
-    setErrorObj(new CyError());
+    clearErrorObj();
 
     startDeviceUpdate();
 

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/cardAuth.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/cardAuth.tsx
@@ -1,5 +1,5 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import { Grid } from '@mui/material';
+import { Grid, Tooltip } from '@mui/material';
 import Step from '@mui/material/Step';
 import StepConnector from '@mui/material/StepConnector';
 import { StepIconProps } from '@mui/material/StepIcon';
@@ -390,13 +390,30 @@ const CardAuth: React.FC<DeviceSettingItemProps> = ({
             </div>
           ) : (
             <div className={classes.errorButtons}>
-              <CustomButton
-                variant="outlined"
-                onClick={handleRetry}
-                style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
-              >
-                Retry
-              </CustomButton>
+              {!latestDeviceConnection.current ? (
+                <Tooltip
+                  title={'Reconnect the device to retry'}
+                  placement="top"
+                >
+                  <div>
+                    <CustomButton
+                      variant="outlined"
+                      style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
+                      disabled
+                    >
+                      Retry
+                    </CustomButton>
+                  </div>
+                </Tooltip>
+              ) : (
+                <CustomButton
+                  variant="outlined"
+                  onClick={handleRetry}
+                  style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
+                >
+                  Retry
+                </CustomButton>
+              )}
               <CustomButton
                 color="primary"
                 onClick={handleFeedbackOpen}

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
@@ -22,7 +22,6 @@ import AvatarIcon from '../../../../../../designSystem/designComponents/icons/Av
 import Icon from '../../../../../../designSystem/designComponents/icons/Icon';
 import ErrorExclamation from '../../../../../../designSystem/iconGroups/errorExclamation';
 import ICONS from '../../../../../../designSystem/iconGroups/iconConstants';
-import { CyError } from '../../../../../../errors';
 import { useDeviceAuth } from '../../../../../../store/hooks/flows';
 import { useConnection } from '../../../../../../store/provider';
 import Analytics from '../../../../../../utils/analytics';

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
@@ -259,7 +259,7 @@ const DeviceAuth: React.FC<DeviceSettingItemProps> = ({
     resetHooks,
     errorObj,
     cancelDeviceAuth,
-    setErrorObj,
+    clearErrorObj,
     confirmed,
     handleFeedbackOpen
   } = useDeviceAuth();
@@ -345,7 +345,7 @@ const DeviceAuth: React.FC<DeviceSettingItemProps> = ({
 
   const handleRetry = () => {
     logger.info('Device authentication retry');
-    setErrorObj(new CyError());
+    clearErrorObj();
     setCompleted(0);
     resetHooks();
     if (deviceConnection) {

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceAuth.tsx
@@ -13,6 +13,7 @@ import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import clsx from 'clsx';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import success from '../../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../../designSystem/designComponents/buttons/button';
@@ -265,6 +266,16 @@ const DeviceAuth: React.FC<DeviceSettingItemProps> = ({
 
   const latestDeviceConnection = useRef<any>();
   const latestCompleted = useRef<boolean>();
+
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const isRefresh = Boolean(query.get('isRefresh'));
+
+  useEffect(() => {
+    if (isRefresh) {
+      handleRetry();
+    }
+  }, [isRefresh]);
 
   useEffect(() => {
     latestDeviceConnection.current = deviceConnection;

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
@@ -263,7 +263,7 @@ const DeviceUpgrade: React.FC<DeviceSettingItemProps> = ({
     errorObj,
     handleFeedbackOpen,
     latestVersion,
-    downloadFirmware,
+    checkLatestFirmware,
     upgradeAvailable
   } = useDeviceUpgrade();
 
@@ -326,7 +326,7 @@ const DeviceUpgrade: React.FC<DeviceSettingItemProps> = ({
         setIsCompleted(-1);
         setAuthState(-1);
       };
-      downloadFirmware(onSuccess, onError);
+      checkLatestFirmware(onSuccess, onError);
     }
   }, [authState]);
 

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
@@ -12,6 +12,7 @@ import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import clsx from 'clsx';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import success from '../../../../../../assets/icons/generic/success.png';
 import CustomButton from '../../../../../../designSystem/designComponents/buttons/button';
@@ -271,6 +272,16 @@ const DeviceUpgrade: React.FC<DeviceSettingItemProps> = ({
   const latestCompleted = useRef<boolean>();
   const latestStep = useRef<number>();
 
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const isRefresh = Boolean(query.get('isRefresh'));
+
+  useEffect(() => {
+    if (isRefresh) {
+      handleRetry();
+    }
+  }, [isRefresh]);
+
   useEffect(() => {
     latestDeviceConnection.current = deviceConnection;
   }, [deviceConnection]);
@@ -502,27 +513,6 @@ const DeviceUpgrade: React.FC<DeviceSettingItemProps> = ({
             {errorObj.showError()}
           </Typography>
           <div className={classes.errorButtons}>
-            {!latestDeviceConnection.current ? (
-              <Tooltip title={'Reconnect the device to retry'} placement="top">
-                <div>
-                  <CustomButton
-                    color="primary"
-                    style={{ padding: '0.5rem 2rem' }}
-                    disabled
-                  >
-                    Retry
-                  </CustomButton>
-                </div>
-              </Tooltip>
-            ) : (
-              <CustomButton
-                color="primary"
-                onClick={handleRetry}
-                style={{ padding: '0.5rem 2rem' }}
-              >
-                Retry
-              </CustomButton>
-            )}
             {!latestDeviceConnection.current ? (
               <Tooltip title={'Reconnect the device to retry'} placement="top">
                 <div>

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceHealth/deviceUpgrade.tsx
@@ -1,6 +1,6 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AlertIcon from '@mui/icons-material/ReportProblemOutlined';
-import { Button, Grid } from '@mui/material';
+import { Button, Grid, Tooltip } from '@mui/material';
 import Step from '@mui/material/Step';
 import StepConnector from '@mui/material/StepConnector';
 import { StepIconProps } from '@mui/material/StepIcon';
@@ -502,13 +502,48 @@ const DeviceUpgrade: React.FC<DeviceSettingItemProps> = ({
             {errorObj.showError()}
           </Typography>
           <div className={classes.errorButtons}>
-            <CustomButton
-              variant="outlined"
-              onClick={handleOnRetry}
-              style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
-            >
-              Retry
-            </CustomButton>
+            {!latestDeviceConnection.current ? (
+              <Tooltip title={'Reconnect the device to retry'} placement="top">
+                <div>
+                  <CustomButton
+                    color="primary"
+                    style={{ padding: '0.5rem 2rem' }}
+                    disabled
+                  >
+                    Retry
+                  </CustomButton>
+                </div>
+              </Tooltip>
+            ) : (
+              <CustomButton
+                color="primary"
+                onClick={handleRetry}
+                style={{ padding: '0.5rem 2rem' }}
+              >
+                Retry
+              </CustomButton>
+            )}
+            {!latestDeviceConnection.current ? (
+              <Tooltip title={'Reconnect the device to retry'} placement="top">
+                <div>
+                  <CustomButton
+                    variant="outlined"
+                    style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
+                    disabled
+                  >
+                    Retry
+                  </CustomButton>
+                </div>
+              </Tooltip>
+            ) : (
+              <CustomButton
+                variant="outlined"
+                onClick={handleOnRetry}
+                style={{ textTransform: 'none', padding: '0.5rem 2rem' }}
+              >
+                Retry
+              </CustomButton>
+            )}
             <CustomButton
               color="primary"
               onClick={handleFeedbackOpen}

--- a/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceSettings.tsx
+++ b/cysync/src/pages/mainApp/sidebar/settings/tabViews/deviceSettings.tsx
@@ -124,7 +124,7 @@ const DeviceSettings = ({ allowExit, setAllowExit }: DeviceSettingsProps) => {
   const handleDeviceHealthTabOpen = (index: number) => {
     if (beforeNetworkAction()) {
       // Disable Internal Device Auth Popup if Device auth or Device upgrade is selected
-      if ([0, 1].includes(index) || beforeFlowStart()) {
+      if ([0].includes(index) || beforeFlowStart()) {
         navigate(DeviceHealthItems[index].route);
       }
     }

--- a/cysync/src/store/hooks/flows/useAddCoin.ts
+++ b/cysync/src/store/hooks/flows/useAddCoin.ts
@@ -123,7 +123,7 @@ export const useAddCoin: UseAddCoin = () => {
 
   const clearAll = () => {
     setIsCancelled(false);
-    setErrorObj(new CyError());
+    clearErrorObj();
     resetHooks();
   };
 

--- a/cysync/src/store/hooks/flows/useDeviceUpgrade.ts
+++ b/cysync/src/store/hooks/flows/useDeviceUpgrade.ts
@@ -475,7 +475,6 @@ export const useDeviceUpgrade: UseDeviceUpgrade = (isInitial?: boolean) => {
 
       if (retries.current > MAX_RETRIES) {
         logger.warn('Error in device auth, max retries exceeded.');
-        logger.error(error);
         if (
           !(
             errorObj.isSet &&
@@ -486,7 +485,7 @@ export const useDeviceUpgrade: UseDeviceUpgrade = (isInitial?: boolean) => {
             CysyncError.DEVICE_UPGRADE_CONNECTION_FAILED_IN_AUTH,
             langStrings.ERRORS.DEVICE_UPGRADE_CONNECTION_FAILED_IN_AUTH
           );
-          setErrorObj(handleErrors(errorObj, cyError, flowName));
+          setErrorObj(handleErrors(errorObj, cyError, flowName, { error }));
         }
         setIsCompleted(-1);
         setIsDeviceUpdating(false);

--- a/cysync/src/store/hooks/flows/useReceiveTransation.ts
+++ b/cysync/src/store/hooks/flows/useReceiveTransation.ts
@@ -131,17 +131,11 @@ export const useReceiveTransaction: UseReceiveTransaction = () => {
       });
 
       if (!connection) {
-        setErrorObj(
-          handleErrors(
-            errorObj,
-            new CyError(
-              DeviceErrorType.NOT_CONNECTED,
-              langStrings.ERRORS.DEVICE_NOT_CONNECTED
-            ),
-            flowName,
-            { coinType }
-          )
+        const cyError = new CyError(
+          DeviceErrorType.NOT_CONNECTED,
+          langStrings.ERRORS.DEVICE_NOT_CONNECTED
         );
+        setErrorObj(handleErrors(errorObj, cyError, flowName, { coinType }));
         return;
       }
 
@@ -154,17 +148,11 @@ export const useReceiveTransaction: UseReceiveTransaction = () => {
       });
 
       receiveTransaction.on('cardError', () => {
-        setErrorObj(
-          handleErrors(
-            errorObj,
-            new CyError(
-              CysyncError.UNKNOWN_CARD_ERROR,
-              langStrings.ERRORS.UNKNOWN_CARD_ERROR
-            ),
-            flowName,
-            { coinType }
-          )
+        const cyError = new CyError(
+          CysyncError.UNKNOWN_CARD_ERROR,
+          langStrings.ERRORS.UNKNOWN_CARD_ERROR
         );
+        setErrorObj(handleErrors(errorObj, cyError, flowName, { coinType }));
       });
 
       receiveTransaction.on('error', err => {

--- a/cysync/src/store/hooks/flows/useSendTransaction.ts
+++ b/cysync/src/store/hooks/flows/useSendTransaction.ts
@@ -387,17 +387,11 @@ export const useSendTransaction: UseSendTransaction = () => {
       });
 
       if (!connection) {
-        setErrorObj(
-          handleErrors(
-            errorObj,
-            new CyError(
-              DeviceErrorType.NOT_CONNECTED,
-              langStrings.ERRORS.DEVICE_NOT_CONNECTED
-            ),
-            flowName,
-            { coinType }
-          )
+        const cyError = new CyError(
+          DeviceErrorType.NOT_CONNECTED,
+          langStrings.ERRORS.DEVICE_NOT_CONNECTED
         );
+        setErrorObj(handleErrors(errorObj, cyError, flowName, { coinType }));
         return;
       }
 
@@ -410,17 +404,11 @@ export const useSendTransaction: UseSendTransaction = () => {
       });
 
       sendTransaction.on('cardError', () => {
-        setErrorObj(
-          handleErrors(
-            errorObj,
-            new CyError(
-              CysyncError.UNKNOWN_CARD_ERROR,
-              langStrings.ERRORS.UNKNOWN_CARD_ERROR
-            ),
-            flowName,
-            { coinType }
-          )
+        const cyError = new CyError(
+          CysyncError.UNKNOWN_CARD_ERROR,
+          langStrings.ERRORS.UNKNOWN_CARD_ERROR
         );
+        setErrorObj(handleErrors(errorObj, cyError, flowName, { coinType }));
       });
 
       sendTransaction.on('error', err => {

--- a/cysync/src/store/provider/tutorialProvider.tsx
+++ b/cysync/src/store/provider/tutorialProvider.tsx
@@ -4,7 +4,13 @@ import React, { useState } from 'react';
 
 import { version } from '../../../package.json';
 import ErrorDialog from '../../designSystem/designComponents/dialog/errorDialog';
-import { CyError, CysyncError } from '../../errors';
+import {
+  CyError,
+  CyError,
+  CysyncError,
+  handleAxiosErrors,
+  handleErrors
+} from '../../errors';
 import logger from '../../utils/logger';
 
 import { useI18n } from './i18nProvider';
@@ -52,32 +58,16 @@ export const TutorialProvider: React.FC = ({ children }) => {
         throw new Error('Cannot find tutorials.');
       }
     } catch (error) {
-      logger.error(error);
-
+      const cyError = new CyError();
       if (error.isAxiosError) {
-        if (error.response) {
-          setErrorObj(
-            new CyError(
-              CysyncError.NETWORK_ERROR,
-              langStrings.ERRORS.NETWORK_ERROR
-            )
-          );
-        } else {
-          setErrorObj(
-            new CyError(
-              CysyncError.NETWORK_UNREACHABLE,
-              langStrings.ERRORS.NETWORK_UNREACHABLE
-            )
-          );
-        }
+        handleAxiosErrors(cyError, error, langStrings);
       } else {
-        setErrorObj(
-          new CyError(
-            CysyncError.CUSTOM_ERROR,
-            langStrings.ERRORS.CUSTOM_ERROR('fetching the tutorials.')
-          )
+        cyError.setError(
+          CysyncError.CUSTOM_ERROR,
+          langStrings.ERRORS.CUSTOM_ERROR('fetching the tutorials.')
         );
       }
+      setErrorObj(handleErrors(errorObj, cyError, _, error));
     } finally {
       setIsLoading(false);
     }

--- a/cysync/src/store/provider/tutorialProvider.tsx
+++ b/cysync/src/store/provider/tutorialProvider.tsx
@@ -6,12 +6,10 @@ import { version } from '../../../package.json';
 import ErrorDialog from '../../designSystem/designComponents/dialog/errorDialog';
 import {
   CyError,
-  CyError,
   CysyncError,
   handleAxiosErrors,
   handleErrors
 } from '../../errors';
-import logger from '../../utils/logger';
 
 import { useI18n } from './i18nProvider';
 
@@ -67,7 +65,7 @@ export const TutorialProvider: React.FC = ({ children }) => {
           langStrings.ERRORS.CUSTOM_ERROR('fetching the tutorials.')
         );
       }
-      setErrorObj(handleErrors(errorObj, cyError, _, error));
+      setErrorObj(handleErrors(errorObj, cyError, 'Tutorials', error));
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
Settings Issues
- internet disconnected slow popup occurs randomly
- device doesnt get detected if you connect it later on device auth too
- weird issues happen in device disconnection mode
while device is connecting the user shouldnt be let inside

Retry Button
- disable retry button when device is not connected
- when disabled show a tooltip

Auth & Upgrade Redirection
- set a flag in route so that it resets the state


Complete Revisit
- handleErrors middleware is used or not
- use the standard errorObj functions everywhere