### PR TITLE
CSI-1229 change totalfees to a string

### DIFF
--- a/cysync/package.json
+++ b/cysync/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@cypherock/communication": "3.0.1-beta.26",
     "@cypherock/database": "3.0.1-beta.33",
-    "@cypherock/protocols": "3.0.1-beta.54",
+    "@cypherock/protocols": "3.0.1-beta.55",
     "@cypherock/server-wrapper": "1.0.1-beta.19",
     "@cypherock/wallet": "3.0.1-beta.46",
     "@emotion/react": "^11.9.0",

--- a/cysync/src/pages/mainApp/sidebar/wallet/addAccount/formStepComponents/Verify.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/addAccount/formStepComponents/Verify.tsx
@@ -182,7 +182,8 @@ const Verify = (props: any) => {
           <LabelText
             label="Transaction Fees"
             text={`~ ${0.1012} ${coinDetails.slug.toUpperCase()} ( $${formatDisplayAmount(
-              sendTransaction.totalFees * parseFloat(coinDetails.displayPrice),
+              parseFloat(sendTransaction.totalFees) *
+                parseFloat(coinDetails.displayPrice),
               2,
               true
             )})`}

--- a/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Summary.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Summary.tsx
@@ -255,7 +255,8 @@ const Summary: React.FC<StepComponentProps> = ({
           text={`~ ${
             sendTransaction.totalFees
           } ${coinDetails.slug.toUpperCase()} ~( $${formatDisplayAmount(
-            sendTransaction.totalFees * parseFloat(coinDetails.displayPrice),
+            parseFloat(sendTransaction.totalFees) *
+              parseFloat(coinDetails.displayPrice),
             2,
             true
           )})`}

--- a/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Verify.tsx
+++ b/cysync/src/pages/mainApp/sidebar/wallet/send/formStepComponents/Verify.tsx
@@ -198,7 +198,7 @@ const Verify = (props: any) => {
               text={`~ ${
                 sendTransaction.totalFees
               } ${coinDetails.slug.toUpperCase()} ( $${formatDisplayAmount(
-                sendTransaction.totalFees *
+                parseFloat(sendTransaction.totalFees) *
                   parseFloat(coinDetails.displayPrice),
                 2,
                 true
@@ -245,7 +245,7 @@ const Verify = (props: any) => {
                 text={`~ ${
                   sendTransaction.totalFees
                 } ${coinDetails.slug.toUpperCase()} ~( $${
-                  sendTransaction.totalFees *
+                  parseFloat(sendTransaction.totalFees) *
                   parseFloat(coinDetails.displayPrice)
                 })`}
                 verified={sendTransaction.verified}

--- a/cysync/src/store/hooks/flows/useSendTransaction.ts
+++ b/cysync/src/store/hooks/flows/useSendTransaction.ts
@@ -171,7 +171,7 @@ export interface UseSendTransactionValues {
   signedTxn: string;
   hash: string;
   setHash: React.Dispatch<React.SetStateAction<string>>;
-  totalFees: number;
+  totalFees: string;
   approxTotalFee: number;
   sendMaxAmount: string;
   resetHooks: () => void;
@@ -217,7 +217,7 @@ export const useSendTransaction: UseSendTransaction = () => {
   const [hash, setHash] = useState('');
   const [metadataSent, setMetadataSent] = useState(false);
   const sendTransaction = new TransactionSender();
-  const [totalFees, setTotalFees] = useState(0);
+  const [totalFees, setTotalFees] = useState('0');
   const [txnInputs, setTxnInputs] = useState<TxInputOutput[]>([]);
   const [txnOutputs, setTxnOutputs] = useState<TxInputOutput[]>([]);
   const [approxTotalFee, setApproxTotalFees] = useState(0);
@@ -240,7 +240,7 @@ export const useSendTransaction: UseSendTransaction = () => {
     setCompleted(false);
     setMetadataSent(false);
     setEstimationError(undefined);
-    setTotalFees(0);
+    setTotalFees('0');
     setSendMaxAmount('0');
     sendTransaction.removeAllListeners();
   };

--- a/cysync/yarn.lock
+++ b/cysync/yarn.lock
@@ -199,10 +199,10 @@
     transform-pouch "^2.0.0"
     winston "^3.6.0"
 
-"@cypherock/protocols@3.0.1-beta.54":
-  version "3.0.1-beta.54"
-  resolved "https://registry.yarnpkg.com/@cypherock/protocols/-/protocols-3.0.1-beta.54.tgz#165bd246cae0f80c52f9e4f9385ece9b193969c3"
-  integrity sha512-RPRdEyaWXuEYVMkVkJbXL+9pV8tmO8txyMPCYoU6VHuh/SZyD/vSfsaJSJz1mzxCBM+VEvH3PGH4WGEk1MOyDA==
+"@cypherock/protocols@3.0.1-beta.55":
+  version "3.0.1-beta.55"
+  resolved "https://registry.yarnpkg.com/@cypherock/protocols/-/protocols-3.0.1-beta.55.tgz#8d2242d4886075d7e25f5f0cc30e460b787b3f54"
+  integrity sha512-ZUVC5CtjCx9sEdKJk7Mz0p5Wab/mF/EjkwOtQXJobRSTEjBGn1PrYPgrPhjMeml/Wmug10OGegAQ4LnJG6bKdQ==
   dependencies:
     "@cypherock/communication" "3.0.1-beta.26"
     "@cypherock/database" "3.0.1-beta.33"


### PR DESCRIPTION
Converting totalFees to a string to prevent javascript floating point precision error.