### PR TITLE
Bump fix: add delay in card auth when device not ready

### DIFF
--- a/cysync/src/store/hooks/flows/useCardAuth.ts
+++ b/cysync/src/store/hooks/flows/useCardAuth.ts
@@ -399,6 +399,7 @@ export const useCardAuth: UseCardAuth = isInitial => {
       }
       setErrorObj(handleErrors(errorObj, cyError, flowName));
     });
+    await sleep(600); // for UI purposes
 
     try {
       setIsInFlow(true);


### PR DESCRIPTION
Added 600ms delay when device is not ready for better ux